### PR TITLE
number_of_cycles=0 is changed to None in factory

### DIFF
--- a/contract/src/instruction/factory/initialize_auction.rs
+++ b/contract/src/instruction/factory/initialize_auction.rs
@@ -4,7 +4,7 @@ use std::convert::TryInto;
 
 // TODO: Optional max supply for ERC20 tokens
 
-#[derive(BorshSchema, BorshSerialize, BorshDeserialize)]
+#[derive(BorshSchema, BorshSerialize, BorshDeserialize, Clone)]
 pub struct InitializeAuctionArgs {
     pub auction_owner_pubkey: Pubkey,
     #[alias([u8; 32])]
@@ -63,6 +63,11 @@ impl InitializeAuctionArgs {
 }
 
 pub fn initialize_auction(args: &InitializeAuctionArgs) -> Instruction {
+    let mut args_checked = args.clone();
+    if args.auction_config.number_of_cycles == Some(0) {
+        args_checked.auction_config.number_of_cycles = None;
+    }
+
     let (auction_root_state_pubkey, _) =
         Pubkey::find_program_address(&auction_root_state_seeds(&args.auction_id), &crate::ID);
     let (auction_cycle_state_pubkey, _) = Pubkey::find_program_address(

--- a/contract/src/instruction/factory/initialize_auction.rs
+++ b/contract/src/instruction/factory/initialize_auction.rs
@@ -63,9 +63,9 @@ impl InitializeAuctionArgs {
 }
 
 pub fn initialize_auction(args: &InitializeAuctionArgs) -> Instruction {
-    let mut args_checked = args.clone();
+    let mut config_checked = args.auction_config;
     if args.auction_config.number_of_cycles == Some(0) {
-        args_checked.auction_config.number_of_cycles = None;
+        config_checked.number_of_cycles = None;
     }
 
     let (auction_root_state_pubkey, _) =
@@ -116,7 +116,7 @@ pub fn initialize_auction(args: &InitializeAuctionArgs) -> Instruction {
     let instruction = AuctionInstruction::InitializeAuction {
         id: args.auction_id,
         auction_name: args.auction_name,
-        auction_config: args.auction_config,
+        auction_config: config_checked,
         description: args.auction_description.clone(),
         create_token_args: args.create_token_args.clone(),
         auction_start_timestamp: args.auction_start_timestamp,


### PR DESCRIPTION
# Description

If `number_of_cycles` is set to 0 on initialize auction call through the factory, it is replaced with `None` to represent infinite auctions. 