### PR TITLE
`spl-token` version bump.

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -13,9 +13,9 @@ agsol-wasm-client = { version = "0.0.1", features = ["wasm-factory"] }
 anyhow = "1"
 borsh = "0.9.0"
 js-sys = "0.3"
-metaplex-token-metadata = { git = "https://github.com/zgendao/metaplex", branch = "experiments", features = ["no-entrypoint"] }
+metaplex-token-metadata = { git = "https://github.com/zgendao/metaplex", branch = "spl-bump", features = ["no-entrypoint"] }
 serde_json = "1.0"
-spl-token = { git = "https://github.com/zgendao/solana-program-library.git", features = ["no-entrypoint"] }
+spl-token = { version = "3.3.0", features = ["no-entrypoint"] }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 

--- a/contract/Cargo.toml
+++ b/contract/Cargo.toml
@@ -16,12 +16,12 @@ agsol-borsh-schema = "0.0.1"
 agsol-common = { version = "0.2.0", features = ["derive"] }
 borsh = "0.9.0"
 borsh-derive = "0.9.0"
-metaplex-token-metadata = { git = "https://github.com/zgendao/metaplex", branch = "experiments", features = ["no-entrypoint"] }
+metaplex-token-metadata = { git = "https://github.com/zgendao/metaplex", branch = "spl-bump", features = ["no-entrypoint"] }
 num-derive = { version = "0.3", optional = true }
 num-traits = { version = "0.2", optional = true }
 solana-program = "1.9.0"
-spl-token = { git = "https://github.com/zgendao/solana-program-library.git", features = ["no-entrypoint"] }
+spl-token = { version = "3.3.0", features = ["no-entrypoint"] }
 
 [dev-dependencies]
-agsol-testbench = { git = "https://github.com/agoraxyz/agora-solana.git" }
+agsol-testbench = "0.0.1-alpha.1"
 solana-sdk = "1.9.0"


### PR DESCRIPTION
## Description
`spl_token` v3.3.0` is out, which is wasm-compatible, so the respective dependencies has been updated. Aims to close #28 