### PR TITLE
Auto-filter on idle cycles

### DIFF
--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -39,9 +39,13 @@ pub const MAX_SOCIALS_NUM: usize = 5;
 /// development.
 pub const EXTRA_ROOT_STATE_BYTES: usize = 32;
 /// Allowed time period for an auction to go without a bid placed on it before
-/// it is automatically frozen at cycle closing.
+/// it is automatically filtered at cycle closing.
 /// Currently set for a week of inactivity.
 pub const ALLOWED_AUCTION_IDLE_PERIOD: UnixTimestamp = 604_800;
+/// Allowed number of cycles for an auction to go without a bid placed on it before
+/// it is automatically filtered at cycle closing.
+/// More relevant than `ALLOWED_AUCTION_IDLE_PERIOD` in auctions with low cycle periods.
+pub const ALLOWED_CONSECUTIVE_IDLE_CYCLES: u32 = 50;
 /// Minimum bid amount on any auction cycle in Lamports.
 pub const UNIVERSAL_BID_FLOOR: u64 = 50_000_000;
 /// Minimum length of an auction cycle period in seconds.

--- a/contract/src/processor/close_auction_cycle.rs
+++ b/contract/src/processor/close_auction_cycle.rs
@@ -469,7 +469,6 @@ pub fn close_auction_cycle(
     Ok(())
 }
 
-
 fn increment_idle_streak(
     current_auction_cycle_state: &mut AuctionCycleState,
     auction_root_state: &mut AuctionRootState,
@@ -658,4 +657,3 @@ mod cycle_increment_tests {
         assert_eq!(long_uri, long_uri_expected);
     }
 }
-

--- a/contract/src/processor/close_auction_cycle.rs
+++ b/contract/src/processor/close_auction_cycle.rs
@@ -129,27 +129,12 @@ pub fn close_auction_cycle(
             .checked_add(most_recent_bid.bid_amount)
             .ok_or(AuctionContractError::ArithmeticError)?;
     } else {
-        current_auction_cycle_state.end_time = current_auction_cycle_state
-            .end_time
-            .checked_add(auction_root_state.auction_config.cycle_period)
-            .ok_or(AuctionContractError::ArithmeticError)?;
-
-        auction_root_state.status.current_idle_cycle_streak = auction_root_state
-            .status
-            .current_idle_cycle_streak
-            .checked_add(1)
-            .ok_or(AuctionContractError::ArithmeticError)?;
-
-        // If the auction was idle for at least a week then filter it automatically
-        if auction_root_state.auction_config.cycle_period
-            * UnixTimestamp::from(auction_root_state.status.current_idle_cycle_streak)
-            > crate::ALLOWED_AUCTION_IDLE_PERIOD
-        {
-            auction_root_state.status.is_filtered = true;
-        }
-
-        current_auction_cycle_state.write(current_auction_cycle_state_account)?;
-        auction_root_state.write(auction_root_state_account)?;
+        increment_idle_streak(
+            &mut current_auction_cycle_state,
+            &mut auction_root_state,
+            current_auction_cycle_state_account,
+            auction_root_state_account,
+        )?;
         return Ok(());
     }
 
@@ -484,6 +469,39 @@ pub fn close_auction_cycle(
     Ok(())
 }
 
+
+fn increment_idle_streak(
+    current_auction_cycle_state: &mut AuctionCycleState,
+    auction_root_state: &mut AuctionRootState,
+    current_auction_cycle_state_account: &AccountInfo,
+    auction_root_state_account: &AccountInfo,
+) -> Result<(), ProgramError> {
+    current_auction_cycle_state.end_time = current_auction_cycle_state
+        .end_time
+        .checked_add(auction_root_state.auction_config.cycle_period)
+        .ok_or(AuctionContractError::ArithmeticError)?;
+
+    auction_root_state.status.current_idle_cycle_streak = auction_root_state
+        .status
+        .current_idle_cycle_streak
+        .checked_add(1)
+        .ok_or(AuctionContractError::ArithmeticError)?;
+
+    // If the auction was idle for at least a week then filter it automatically
+    if auction_root_state.auction_config.cycle_period
+        * UnixTimestamp::from(auction_root_state.status.current_idle_cycle_streak)
+        > crate::ALLOWED_AUCTION_IDLE_PERIOD
+        || auction_root_state.status.current_idle_cycle_streak
+            > crate::ALLOWED_CONSECUTIVE_IDLE_CYCLES
+    {
+        auction_root_state.status.is_filtered = true;
+    }
+
+    current_auction_cycle_state.write(current_auction_cycle_state_account)?;
+    auction_root_state.write(auction_root_state_account)?;
+    Ok(())
+}
+
 pub fn increment_name(
     string: &mut String,
     is_last_cycle: bool,
@@ -640,3 +658,4 @@ mod cycle_increment_tests {
         assert_eq!(long_uri, long_uri_expected);
     }
 }
+


### PR DESCRIPTION
## Description

Auctions are now filtered automatically if 50+ consecutive idle cycles are closed. This is independent from the maximum allowed idle period check.

A contract test was added for this new auto filtering condition. An attempt was made to create a test for the idle period check, however, it seems impossible to warp a whole week in the testbench without running out of the 60 second limit of test-bpf.