### PR TITLE
Delete immediately

### DIFF
--- a/contract/src/processor/delete_auction.rs
+++ b/contract/src/processor/delete_auction.rs
@@ -54,12 +54,17 @@ pub fn process_delete_auction(
         secondary_pool_account,
     )?;
 
-    SignerPda::check_owner(
-        &auction_bank_seeds(&auction_id),
-        program_id,
-        program_id,
-        auction_bank_account,
-    )?;
+    if auction_bank_account.lamports() != 0 {
+        SignerPda::check_owner(
+            &auction_bank_seeds(&auction_id),
+            program_id,
+            program_id,
+            auction_bank_account,
+        )?;
+    } else {
+        let auction_bank_seeds = auction_bank_seeds(&auction_id);
+        SignerPda::new_checked(&auction_bank_seeds, program_id, auction_bank_account)?;
+    }
 
     // Check auction owner account
     let mut auction_root_state = AuctionRootState::read(auction_root_state_account)?;
@@ -89,7 +94,7 @@ pub fn process_delete_auction(
         )?;
 
         // Refund top bidder of the last cycle
-        if !auction_root_state.status.is_frozen {
+        if !auction_root_state.status.is_frozen && !auction_root_state.status.is_finished {
             let auction_cycle_state = AuctionCycleState::read(auction_cycle_state_account)?;
             refund_top_bidder(
                 auction_bank_account,

--- a/contract/tests/process_delete_auction.rs
+++ b/contract/tests/process_delete_auction.rs
@@ -16,9 +16,6 @@ use agsol_gold_contract::RECOMMENDED_CYCLE_STATES_DELETED_PER_CALL;
 use agsol_testbench::tokio;
 use agsol_testbench::Testbench;
 
-use agsol_gold_contract::utils::pad_to_32_bytes;
-use core::str::FromStr;
-
 #[tokio::test]
 async fn test_delete_auction_immediately() {
     let (mut testbench, auction_owner) = test_factory::testbench_setup().await.unwrap().unwrap();
@@ -91,7 +88,6 @@ async fn test_delete_auction_immediately() {
         .unwrap();
     assert_eq!(auction_pool.pool.len(), 0);
 
-
     // Test if state accounts are deleted
     assert!(
         !is_existing_account(&mut testbench, &auction_root_state_pubkey)
@@ -145,38 +141,14 @@ async fn test_delete_small_auction() {
 
     assert_eq!(auction_root_state.status.current_auction_cycle, 4);
 
-    let (auction_cycle_state_pubkey, _) = Pubkey::find_program_address(
-        &auction_cycle_state_seeds(
-            &auction_root_state_pubkey,
-            &auction_root_state
-                .status
-                .current_auction_cycle
-                .to_le_bytes(),
-        ),
-        &CONTRACT_ID,
-    );
-
-    let delete_auction_args = DeleteAuctionArgs {
-        auction_owner_pubkey: auction_owner.keypair.pubkey(),
-        top_bidder_pubkey: get_top_bidder_pubkey(&mut testbench, &auction_cycle_state_pubkey)
-            .await
-            .unwrap(),
-        auction_id,
-        current_auction_cycle: get_current_cycle_number(&mut testbench, &auction_root_state_pubkey)
-            .await
-            .unwrap(),
-        num_of_cycles_to_delete: RECOMMENDED_CYCLE_STATES_DELETED_PER_CALL,
-    };
-    let delete_auction_ix = delete_auction(&delete_auction_args);
-
     // Delete auction
     let auction_pool = testbench
         .get_and_deserialize_account_data::<AuctionPool>(&auction_pool_pubkey)
         .await
         .unwrap();
     assert_eq!(auction_pool.pool.len(), 1);
-    testbench
-        .process_transaction(&[delete_auction_ix], &auction_owner.keypair, None)
+
+    delete_auction_transaction(&mut testbench, &auction_owner.keypair, auction_id)
         .await
         .unwrap()
         .unwrap();
@@ -198,6 +170,96 @@ async fn test_delete_small_auction() {
         .await
         .unwrap());
     assert!(are_given_cycle_states_deleted(&mut testbench, &auction_root_state_pubkey, 1, 4).await);
+}
+
+#[tokio::test]
+async fn test_delete_claimed_auction() {
+    let (mut testbench, auction_owner) = test_factory::testbench_setup().await.unwrap().unwrap();
+
+    let auction_id = [1; 32];
+    let auction_config = AuctionConfig {
+        cycle_period: 60,
+        encore_period: 0,
+        minimum_bid_amount: 50_000_000, // lamports
+        number_of_cycles: Some(3),
+    };
+
+    let payer = testbench.clone_payer();
+
+    initialize_new_auction(
+        &mut testbench,
+        &auction_owner.keypair,
+        &auction_config,
+        auction_id,
+        TokenType::Nft,
+    )
+    .await
+    .unwrap()
+    .unwrap();
+
+    let (secondary_pool_pubkey, _) =
+        Pubkey::find_program_address(&secondary_pool_seeds(), &CONTRACT_ID);
+    let (auction_root_state_pubkey, _) =
+        Pubkey::find_program_address(&auction_root_state_seeds(&auction_id), &CONTRACT_ID);
+    let (auction_bank_pubkey, _) =
+        Pubkey::find_program_address(&auction_bank_seeds(&auction_id), &CONTRACT_ID);
+
+    close_n_cycles(&mut testbench, auction_id, &auction_owner, &payer, 3, 100).await;
+
+    let auction_root_state = testbench
+        .get_and_deserialize_account_data::<AuctionRootState>(&auction_root_state_pubkey)
+        .await
+        .unwrap();
+
+    assert_eq!(auction_root_state.status.current_auction_cycle, 3);
+    assert!(auction_root_state.status.is_finished);
+
+    // Claim all funds from auction so that the auction bank is deallocated
+    let claim_all = testbench
+        .get_account_lamports(&auction_bank_pubkey)
+        .await
+        .unwrap();
+
+    claim_funds_transaction(
+        &mut testbench,
+        auction_id,
+        &auction_owner.keypair,
+        claim_all,
+    )
+    .await
+    .unwrap()
+    .unwrap();
+
+    assert!(!is_existing_account(&mut testbench, &auction_bank_pubkey)
+        .await
+        .unwrap());
+
+    // Delete auction with deallocated bank
+    let secondary_pool = testbench
+        .get_and_deserialize_account_data::<AuctionPool>(&secondary_pool_pubkey)
+        .await
+        .unwrap();
+    assert_eq!(secondary_pool.pool.len(), 1);
+
+    delete_auction_transaction(&mut testbench, &auction_owner.keypair, auction_id)
+        .await
+        .unwrap()
+        .unwrap();
+
+    // Test if auction was removed from the pool
+    let secondary_pool = testbench
+        .get_and_deserialize_account_data::<AuctionPool>(&secondary_pool_pubkey)
+        .await
+        .unwrap();
+    assert!(secondary_pool.pool.is_empty());
+
+    // Test if state accounts are deleted
+    assert!(
+        !is_existing_account(&mut testbench, &auction_root_state_pubkey)
+            .await
+            .unwrap()
+    );
+    assert!(are_given_cycle_states_deleted(&mut testbench, &auction_root_state_pubkey, 1, 3).await);
 }
 
 #[tokio::test]
@@ -249,38 +311,14 @@ async fn test_delete_just_long_enough_finished_auction() {
 
     assert!(auction_root_state.status.is_finished);
 
-    let (auction_cycle_state_pubkey, _) = Pubkey::find_program_address(
-        &auction_cycle_state_seeds(
-            &auction_root_state_pubkey,
-            &auction_root_state
-                .status
-                .current_auction_cycle
-                .to_le_bytes(),
-        ),
-        &CONTRACT_ID,
-    );
-
-    let delete_auction_args = DeleteAuctionArgs {
-        auction_owner_pubkey: auction_owner.keypair.pubkey(),
-        top_bidder_pubkey: get_top_bidder_pubkey(&mut testbench, &auction_cycle_state_pubkey)
-            .await
-            .unwrap(),
-        auction_id,
-        current_auction_cycle: get_current_cycle_number(&mut testbench, &auction_root_state_pubkey)
-            .await
-            .unwrap(),
-        num_of_cycles_to_delete: RECOMMENDED_CYCLE_STATES_DELETED_PER_CALL,
-    };
-    let delete_auction_ix = delete_auction(&delete_auction_args);
-
     // Delete auction
     let secondary_pool = testbench
         .get_and_deserialize_account_data::<AuctionPool>(&secondary_pool_pubkey)
         .await
         .unwrap();
     assert_eq!(secondary_pool.pool.len(), 1);
-    testbench
-        .process_transaction(&[delete_auction_ix.clone()], &auction_owner.keypair, None)
+
+    delete_auction_transaction(&mut testbench, &auction_owner.keypair, auction_id)
         .await
         .unwrap()
         .unwrap();
@@ -345,31 +383,8 @@ async fn test_delete_long_ongoing_auction() {
         .await
         .unwrap();
 
+    // Assert that the auction is still ongoing
     assert!(!auction_root_state.status.is_finished);
-
-    let (auction_cycle_state_pubkey, _) = Pubkey::find_program_address(
-        &auction_cycle_state_seeds(
-            &auction_root_state_pubkey,
-            &auction_root_state
-                .status
-                .current_auction_cycle
-                .to_le_bytes(),
-        ),
-        &CONTRACT_ID,
-    );
-
-    let mut delete_auction_args = DeleteAuctionArgs {
-        auction_owner_pubkey: auction_owner.keypair.pubkey(),
-        top_bidder_pubkey: get_top_bidder_pubkey(&mut testbench, &auction_cycle_state_pubkey)
-            .await
-            .unwrap(),
-        auction_id,
-        current_auction_cycle: get_current_cycle_number(&mut testbench, &auction_root_state_pubkey)
-            .await
-            .unwrap(),
-        num_of_cycles_to_delete: RECOMMENDED_CYCLE_STATES_DELETED_PER_CALL,
-    };
-    let delete_auction_ix = delete_auction(&delete_auction_args);
 
     // Delete auction
     let auction_pool = testbench
@@ -377,8 +392,8 @@ async fn test_delete_long_ongoing_auction() {
         .await
         .unwrap();
     assert_eq!(auction_pool.pool.len(), 1);
-    testbench
-        .process_transaction(&[delete_auction_ix], &auction_owner.keypair, None)
+
+    delete_auction_transaction(&mut testbench, &auction_owner.keypair, auction_id)
         .await
         .unwrap()
         .unwrap();
@@ -411,13 +426,8 @@ async fn test_delete_long_ongoing_auction() {
         .unwrap();
     assert!(auction_root_state.status.is_frozen);
 
-    delete_auction_args.current_auction_cycle =
-        get_current_cycle_number(&mut testbench, &auction_root_state_pubkey)
-            .await
-            .unwrap();
-    let delete_auction_ix = delete_auction(&delete_auction_args);
-    testbench
-        .process_transaction(&[delete_auction_ix], &auction_owner.keypair, None)
+    // Finish deleting the auction
+    delete_auction_transaction(&mut testbench, &auction_owner.keypair, auction_id)
         .await
         .unwrap()
         .unwrap();

--- a/contract/tests/process_delete_auction.rs
+++ b/contract/tests/process_delete_auction.rs
@@ -16,6 +16,94 @@ use agsol_gold_contract::RECOMMENDED_CYCLE_STATES_DELETED_PER_CALL;
 use agsol_testbench::tokio;
 use agsol_testbench::Testbench;
 
+use agsol_gold_contract::utils::pad_to_32_bytes;
+use core::str::FromStr;
+
+#[tokio::test]
+async fn test_delete_auction_immediately() {
+    let (mut testbench, auction_owner) = test_factory::testbench_setup().await.unwrap().unwrap();
+
+    let auction_id = [1; 32];
+    let auction_config = AuctionConfig {
+        cycle_period: 60,
+        encore_period: 0,
+        minimum_bid_amount: 50_000_000, // lamports
+        number_of_cycles: Some(10),
+    };
+
+    initialize_new_auction(
+        &mut testbench,
+        &auction_owner.keypair,
+        &auction_config,
+        auction_id,
+        TokenType::Nft,
+    )
+    .await
+    .unwrap()
+    .unwrap();
+
+    let (auction_pool_pubkey, _) =
+        Pubkey::find_program_address(&auction_pool_seeds(), &CONTRACT_ID);
+    let (auction_root_state_pubkey, _) =
+        Pubkey::find_program_address(&auction_root_state_seeds(&auction_id), &CONTRACT_ID);
+    let (auction_bank_pubkey, _) =
+        Pubkey::find_program_address(&auction_bank_seeds(&auction_id), &CONTRACT_ID);
+
+    let auction_root_state = testbench
+        .get_and_deserialize_account_data::<AuctionRootState>(&auction_root_state_pubkey)
+        .await
+        .unwrap();
+
+    let (auction_cycle_state_pubkey, _) = Pubkey::find_program_address(
+        &auction_cycle_state_seeds(
+            &auction_root_state_pubkey,
+            &auction_root_state
+                .status
+                .current_auction_cycle
+                .to_le_bytes(),
+        ),
+        &CONTRACT_ID,
+    );
+
+    let delete_auction_args = DeleteAuctionArgs {
+        auction_owner_pubkey: auction_owner.keypair.pubkey(),
+        top_bidder_pubkey: get_top_bidder_pubkey(&mut testbench, &auction_cycle_state_pubkey)
+            .await
+            .unwrap(),
+        auction_id,
+        current_auction_cycle: get_current_cycle_number(&mut testbench, &auction_root_state_pubkey)
+            .await
+            .unwrap(),
+        num_of_cycles_to_delete: RECOMMENDED_CYCLE_STATES_DELETED_PER_CALL,
+    };
+
+    let delete_auction_ix = delete_auction(&delete_auction_args);
+
+    testbench
+        .process_transaction(&[delete_auction_ix], &auction_owner.keypair, None)
+        .await
+        .unwrap()
+        .unwrap();
+
+    let auction_pool = testbench
+        .get_and_deserialize_account_data::<AuctionPool>(&auction_pool_pubkey)
+        .await
+        .unwrap();
+    assert_eq!(auction_pool.pool.len(), 0);
+
+
+    // Test if state accounts are deleted
+    assert!(
+        !is_existing_account(&mut testbench, &auction_root_state_pubkey)
+            .await
+            .unwrap()
+    );
+    assert!(!is_existing_account(&mut testbench, &auction_bank_pubkey)
+        .await
+        .unwrap());
+    assert!(are_given_cycle_states_deleted(&mut testbench, &auction_root_state_pubkey, 1, 1).await);
+}
+
 #[tokio::test]
 async fn test_delete_small_auction() {
     let (mut testbench, auction_owner) = test_factory::testbench_setup().await.unwrap().unwrap();

--- a/contract/tests/test_factory.rs
+++ b/contract/tests/test_factory.rs
@@ -20,6 +20,7 @@ use agsol_gold_contract::state::{
 };
 use agsol_gold_contract::AuctionContractError;
 use agsol_gold_contract::ID as CONTRACT_ID;
+use agsol_gold_contract::RECOMMENDED_CYCLE_STATES_DELETED_PER_CALL;
 
 use agsol_common::MaxLenString;
 use agsol_testbench::solana_program_test::{self, processor};
@@ -209,6 +210,32 @@ pub async fn close_cycle_transaction(
 
     testbench
         .process_transaction(&[close_auction_cycle_ix], payer_keypair, None)
+        .await
+        .map(|transaction_result| transaction_result.map_err(to_auction_error))
+}
+
+pub async fn delete_auction_transaction(
+    testbench: &mut Testbench,
+    auction_owner_keypair: &Keypair,
+    auction_id: [u8; 32],
+) -> AuctionTransactionResult {
+    let (auction_root_state_pubkey, auction_cycle_state_pubkey) =
+        get_state_pubkeys(testbench, auction_id).await?;
+
+    let current_auction_cycle =
+        get_current_cycle_number(testbench, &auction_root_state_pubkey).await?;
+
+    let delete_auction_args = DeleteAuctionArgs {
+        auction_owner_pubkey: auction_owner_keypair.pubkey(),
+        top_bidder_pubkey: get_top_bidder_pubkey(testbench, &auction_cycle_state_pubkey).await?,
+        auction_id,
+        current_auction_cycle,
+        num_of_cycles_to_delete: RECOMMENDED_CYCLE_STATES_DELETED_PER_CALL,
+    };
+    let delete_auction_ix = delete_auction(&delete_auction_args);
+
+    testbench
+        .process_transaction(&[delete_auction_ix], auction_owner_keypair, None)
         .await
         .map(|transaction_result| transaction_result.map_err(to_auction_error))
 }


### PR DESCRIPTION
## Description

Added tests for immediately deleting an auction after its initialization and deleting an auction after claiming all lamports on the auction bank account. The latter one required adjustements in the deletion instruction to only check the auction bank's owner if the account still exists, and only check its address otherwise.