### PR TITLE
All-time treasure only incremented on cycle close

### DIFF
--- a/contract/src/processor/bid.rs
+++ b/contract/src/processor/bid.rs
@@ -28,7 +28,7 @@ pub fn process_bid(
         auction_root_state_account,
     )?;
 
-    let mut auction_root_state = AuctionRootState::read(auction_root_state_account)?;
+    let auction_root_state = AuctionRootState::read(auction_root_state_account)?;
 
     let cycle_num = auction_root_state
         .status
@@ -72,14 +72,6 @@ pub fn process_bid(
     } else {
         0
     };
-
-    auction_root_state.all_time_treasury = auction_root_state
-        .all_time_treasury
-        .checked_add(amount)
-        .ok_or(AuctionContractError::ArithmeticError)?
-        .checked_sub(previous_bid_amount)
-        .ok_or(AuctionContractError::ArithmeticError)?;
-    auction_root_state.write(auction_root_state_account)?;
 
     // Transfer SOL to fund
     let lamport_transfer_ix =

--- a/contract/src/processor/close_auction_cycle.rs
+++ b/contract/src/processor/close_auction_cycle.rs
@@ -145,6 +145,12 @@ pub fn close_auction_cycle(
             .available_funds
             .checked_add(most_recent_bid.bid_amount)
             .ok_or(AuctionContractError::ArithmeticError)?;
+
+        auction_root_state.all_time_treasury = auction_root_state
+            .all_time_treasury
+            .checked_add(most_recent_bid.bid_amount)
+            .ok_or(AuctionContractError::ArithmeticError)?;
+        auction_root_state.write(auction_root_state_account)?;
     } else {
         increment_idle_streak(
             &mut current_auction_cycle_state,

--- a/contract/src/processor/delete_auction.rs
+++ b/contract/src/processor/delete_auction.rs
@@ -95,7 +95,6 @@ pub fn process_delete_auction(
                 auction_bank_account,
                 top_bidder_account,
                 &auction_cycle_state,
-                &mut auction_root_state,
             )?;
             auction_root_state.status.is_frozen = true;
         }
@@ -146,7 +145,6 @@ fn refund_top_bidder<'a>(
     auction_bank_account: &'a AccountInfo,
     top_bidder_account: &'a AccountInfo,
     auction_cycle_state: &'a AuctionCycleState,
-    auction_root_state: &'a mut AuctionRootState,
 ) -> Result<(), AuctionContractError> {
     let most_recent_bid_option = auction_cycle_state.bid_history.get_last_element();
     if let Some(most_recent_bid) = most_recent_bid_option {
@@ -156,11 +154,6 @@ fn refund_top_bidder<'a>(
 
         checked_debit_account(auction_bank_account, most_recent_bid.bid_amount)?;
         checked_credit_account(top_bidder_account, most_recent_bid.bid_amount)?;
-
-        auction_root_state.all_time_treasury = auction_root_state
-            .all_time_treasury
-            .checked_sub(most_recent_bid.bid_amount)
-            .ok_or(AuctionContractError::ArithmeticError)?;
     }
     Ok(())
 }

--- a/contract/tests/process_bid.rs
+++ b/contract/tests/process_bid.rs
@@ -65,9 +65,6 @@ async fn test_process_bid() {
     .unwrap()
     .unwrap();
 
-    // check state account
-    let (auction_root_state_pubkey, _auction_cycle_state_pubkey) =
-        get_state_pubkeys(&mut testbench, auction_id).await.unwrap();
     let (auction_bank_pubkey, _) =
         Pubkey::find_program_address(&auction_bank_seeds(&auction_id), &CONTRACT_ID);
 
@@ -118,11 +115,12 @@ async fn test_process_bid() {
     assert_eq!(-balance_change as u64, bid_amount + TRANSACTION_FEE);
 
     // Check if treasury is updated
-    let auction_root_state = testbench
-        .get_and_deserialize_account_data::<AuctionRootState>(&auction_root_state_pubkey)
-        .await
-        .unwrap();
-    assert_eq!(auction_root_state.all_time_treasury, bid_amount);
+    assert_eq!(
+        get_bank_balance_without_rent(&mut testbench, auction_id)
+            .await
+            .unwrap(),
+        bid_amount
+    );
 
     // Test higher than current bid
     let bid_amount_higher = 100_000_000;
@@ -156,11 +154,12 @@ async fn test_process_bid() {
     assert_eq!(-balance_change as u64, bid_amount_higher + TRANSACTION_FEE);
 
     // Check if treasury is updated
-    let auction_root_state = testbench
-        .get_and_deserialize_account_data::<AuctionRootState>(&auction_root_state_pubkey)
-        .await
-        .unwrap();
-    assert_eq!(auction_root_state.all_time_treasury, bid_amount_higher);
+    assert_eq!(
+        get_bank_balance_without_rent(&mut testbench, auction_id)
+            .await
+            .unwrap(),
+        bid_amount_higher
+    );
 
     // Invalid use case
     // Test bid lower than current bid

--- a/contract/tests/test_factory.rs
+++ b/contract/tests/test_factory.rs
@@ -13,7 +13,9 @@ use solana_sdk::signer::Signer;
 use solana_sdk::transaction::TransactionError;
 
 use agsol_gold_contract::instruction::factory::*;
-use agsol_gold_contract::pda::{auction_cycle_state_seeds, auction_root_state_seeds};
+use agsol_gold_contract::pda::{
+    auction_bank_seeds, auction_cycle_state_seeds, auction_root_state_seeds,
+};
 use agsol_gold_contract::state::{
     AuctionConfig, AuctionCycleState, AuctionDescription, AuctionRootState, BidData,
     CreateTokenArgs, NftData, TokenConfig, TokenData, TokenType,
@@ -23,7 +25,9 @@ use agsol_gold_contract::ID as CONTRACT_ID;
 
 use agsol_common::MaxLenString;
 use agsol_testbench::solana_program_test::{self, processor};
-use agsol_testbench::{Testbench, TestbenchProgram, TestbenchResult, TestbenchTransactionResult};
+use agsol_testbench::{
+    Testbench, TestbenchError, TestbenchProgram, TestbenchResult, TestbenchTransactionResult,
+};
 
 pub const TRANSACTION_FEE: u64 = 5000;
 pub const INITIAL_AUCTION_POOL_LEN: u32 = 3;
@@ -152,6 +156,30 @@ pub async fn get_top_bid(
         .get_and_deserialize_account_data::<AuctionCycleState>(auction_cycle_state_pubkey)
         .await?;
     Ok(auction_cycle_state.bid_history.get_last_element().cloned())
+}
+
+pub async fn get_bank_balance_without_rent(
+    testbench: &mut Testbench,
+    auction_id: [u8; 32],
+) -> TestbenchResult<u64> {
+    let (auction_bank_pubkey, _) =
+        Pubkey::find_program_address(&auction_bank_seeds(&auction_id), &CONTRACT_ID);
+
+    let (auction_root_state_pubkey, _auction_cycle_state_pubkey) =
+        get_state_pubkeys(testbench, auction_id).await?;
+
+    let auction_root_state = testbench
+        .get_and_deserialize_account_data::<AuctionRootState>(&auction_root_state_pubkey)
+        .await?;
+
+    let mut auction_bank_lamports = testbench.get_account_lamports(&auction_bank_pubkey).await?;
+
+    if !auction_root_state.status.is_finished {
+        auction_bank_lamports = auction_bank_lamports
+            .checked_sub(testbench.rent.minimum_balance(0))
+            .ok_or(TestbenchError::RentError)?;
+    }
+    Ok(auction_bank_lamports)
 }
 
 pub async fn get_top_bidder_pubkey(


### PR DESCRIPTION
## Description

All-time treasury is now only incremented on cycle closing, not after placing a bid, just like the `available_funds`, but it is not decremented when claiming funds.