### PR TITLE
I53 existing mint

### DIFF
--- a/contract/Cargo.toml
+++ b/contract/Cargo.toml
@@ -27,5 +27,5 @@ solana-program = "1.9.0"
 spl-token = { version = "3.3.0", features = ["no-entrypoint"] }
 
 [dev-dependencies]
-agsol-testbench = "0.0.1-alpha.1"
+agsol-testbench = "0.0.1-alpha.2"
 solana-sdk = "1.9.0"

--- a/contract/src/assertions.rs
+++ b/contract/src/assertions.rs
@@ -77,10 +77,10 @@ pub fn assert_mint_authority<'a>(
 // CreateTokenArgs on Token auction creation
 pub fn assert_token_mint_arg_consistency<'a>(
     token_mint_info: &AccountInfo<'a>,
-    existing_account: &Option<Pubkey>,
+    existing_mint: &Option<Pubkey>,
 ) -> Result<(), ProgramError> {
-    if (token_mint_info.data_is_empty() && !existing_account.is_none())
-        || (!token_mint_info.data_is_empty() && existing_account.is_none())
+    if (token_mint_info.data_is_empty() && existing_mint.is_some())
+        || (!token_mint_info.data_is_empty() && existing_mint.is_none())
     {
         return Err(AuctionContractError::TokenAuctionInconsistency.into());
     }

--- a/contract/src/assertions.rs
+++ b/contract/src/assertions.rs
@@ -73,6 +73,43 @@ pub fn assert_mint_authority<'a>(
     Ok(())
 }
 
+// Asserts that the mint's account info is consistent with the data in
+// CreateTokenArgs on Token auction creation
+pub fn assert_token_mint_info<'a>(
+    token_mint_info: &AccountInfo<'a>,
+    existing_account: &Option<Pubkey>,
+) -> Result<(), ProgramError> {
+    if (token_mint_info.data_is_empty() && !existing_account.is_none())
+        || (!token_mint_info.data_is_empty() && existing_account.is_none())
+    {
+        return Err(AuctionContractError::TokenAuctionInconsistency.into());
+    }
+
+    Ok(())
+}
+
+pub fn assert_token_mint<'a>(
+    token_mint_pubkey: &Pubkey,
+    token_mint_account: &AccountInfo<'a>,
+) -> Result<(), ProgramError> {
+    if token_mint_pubkey != token_mint_account.key {
+        return Err(AuctionContractError::TokenAuctionInconsistency.into());
+    }
+
+    Ok(())
+}
+
+pub fn assert_owner<'a>(
+    account: &AccountInfo<'a>,
+    expected_owner: &Pubkey,
+) -> Result<(), ProgramError> {
+    if account.owner != expected_owner {
+        return Err(AuctionContractError::InvalidAccountOwner.into());
+    }
+
+    Ok(())
+}
+
 // ************************ Arithmetic checks ************************ //
 
 pub fn checked_credit_account(

--- a/contract/src/assertions.rs
+++ b/contract/src/assertions.rs
@@ -75,7 +75,7 @@ pub fn assert_mint_authority<'a>(
 
 // Asserts that the mint's account info is consistent with the data in
 // CreateTokenArgs on Token auction creation
-pub fn assert_token_mint_info<'a>(
+pub fn assert_token_mint_arg_consistency<'a>(
     token_mint_info: &AccountInfo<'a>,
     existing_account: &Option<Pubkey>,
 ) -> Result<(), ProgramError> {

--- a/contract/src/error.rs
+++ b/contract/src/error.rs
@@ -36,6 +36,7 @@ pub enum AuctionContractError {
     InvalidPerCycleAmount = 527,      // 20f
     InvalidCyclePeriod = 528,         // 210
     AuctionIdNotAscii = 529,          // 211
+    TokenAuctionInconsistency = 530,  // 212
 }
 
 impl From<AuctionContractError> for ProgramError {

--- a/contract/src/instruction/factory/initialize_auction.rs
+++ b/contract/src/instruction/factory/initialize_auction.rs
@@ -41,7 +41,7 @@ impl InitializeAuctionArgs {
             TokenType::Token => CreateTokenArgs::Token {
                 decimals: 1,
                 per_cycle_amount: 100,
-                existing_account: None,
+                existing_mint: None,
             },
         };
 
@@ -108,9 +108,9 @@ pub fn initialize_auction(args: &InitializeAuctionArgs) -> Instruction {
         CreateTokenArgs::Token {
             decimals: _,
             per_cycle_amount: _,
-            existing_account,
+            existing_mint,
         } => {
-            let mint_pubkey = existing_account.unwrap_or_else(|| {
+            let mint_pubkey = existing_mint.unwrap_or_else(|| {
                 Pubkey::find_program_address(&token_mint_seeds(&args.auction_id), &crate::ID).0
             });
             vec![AccountMeta::new(mint_pubkey, false)]

--- a/contract/src/instruction/factory/initialize_auction.rs
+++ b/contract/src/instruction/factory/initialize_auction.rs
@@ -41,6 +41,7 @@ impl InitializeAuctionArgs {
             TokenType::Token => CreateTokenArgs::Token {
                 decimals: 1,
                 per_cycle_amount: 100,
+                existing_account: None,
             },
         };
 
@@ -104,10 +105,15 @@ pub fn initialize_auction(args: &InitializeAuctionArgs) -> Instruction {
                 AccountMeta::new_readonly(META_ID, false),
             ]
         }
-        CreateTokenArgs::Token { .. } => {
-            let (token_mint_pubkey, _) =
-                Pubkey::find_program_address(&token_mint_seeds(&args.auction_id), &crate::ID);
-            vec![AccountMeta::new(token_mint_pubkey, false)]
+        CreateTokenArgs::Token {
+            decimals: _,
+            per_cycle_amount: _,
+            existing_account,
+        } => {
+            let mint_pubkey = existing_account.unwrap_or_else(|| {
+                Pubkey::find_program_address(&token_mint_seeds(&args.auction_id), &crate::ID).0
+            });
+            vec![AccountMeta::new(mint_pubkey, false)]
         }
     };
 

--- a/contract/src/processor/close_auction_cycle.rs
+++ b/contract/src/processor/close_auction_cycle.rs
@@ -395,15 +395,11 @@ pub fn close_auction_cycle(
             // Check account ownership
             // Accounts created in this instruction:
             //   token_holding_account
+            assert_token_mint(&token_data.mint, token_mint_account)?;
             assert_mint_authority(token_mint_account, contract_pda.key)?;
+            assert_owner(token_mint_account, &TOKEN_ID)?;
 
-            // Check pda addresses
-            SignerPda::check_owner(
-                &token_mint_seeds(&auction_id),
-                program_id,
-                &TOKEN_ID,
-                token_mint_account,
-            )?;
+            // SignerPda check is not required due to the previous checks
 
             if token_mint_account.key != &token_data.mint {
                 return Err(AuctionContractError::InvalidSeeds.into());

--- a/contract/src/processor/initialize_auction.rs
+++ b/contract/src/processor/initialize_auction.rs
@@ -329,7 +329,7 @@ pub fn initialize_auction(
         CreateTokenArgs::Token {
             decimals,
             per_cycle_amount,
-            existing_account,
+            existing_mint,
         } => {
             if per_cycle_amount == 0 {
                 return Err(AuctionContractError::InvalidPerCycleAmount.into());
@@ -340,7 +340,7 @@ pub fn initialize_auction(
             // Accounts (potentially) created in this instruction:
             //   token_mint_account
 
-            assert_token_mint_arg_consistency(token_mint_account, &existing_account)?;
+            assert_token_mint_arg_consistency(token_mint_account, &existing_mint)?;
 
             if token_mint_account.data_is_empty() {
                 // New mint account

--- a/contract/src/processor/initialize_auction.rs
+++ b/contract/src/processor/initialize_auction.rs
@@ -3,6 +3,13 @@ use super::*;
 use crate::{MAX_CYCLE_PERIOD, MIN_CYCLE_PERIOD, UNIVERSAL_BID_FLOOR};
 use solana_program::clock::UnixTimestamp;
 
+// In case of token auction creation there are two possibilities:
+// - Create new mint
+// - Use an existing mint
+
+// If using an existing mint account, the mint authority must be
+// transferred to the contract pda.
+
 #[allow(clippy::too_many_arguments)]
 pub fn initialize_auction(
     program_id: &Pubkey,
@@ -322,6 +329,7 @@ pub fn initialize_auction(
         CreateTokenArgs::Token {
             decimals,
             per_cycle_amount,
+            existing_account,
         } => {
             if per_cycle_amount == 0 {
                 return Err(AuctionContractError::InvalidPerCycleAmount.into());
@@ -329,26 +337,53 @@ pub fn initialize_auction(
             // Parse mint account
             let token_mint_account = next_account_info(account_info_iter)?;
 
-            // Check account ownership
-            // Accounts created in this instruction:
+            // Accounts (potentially) created in this instruction:
             //   token_mint_account
 
-            // Check pda addresses
-            let token_mint_seeds = token_mint_seeds(&auction_id);
-            let token_mint_pda =
-                SignerPda::new_checked(&token_mint_seeds, program_id, token_mint_account)?;
+            assert_token_mint_info(token_mint_account, &existing_account)?;
 
-            // Create ERC20 mint
-            create_mint_account(
-                auction_owner_account,
-                token_mint_account,
-                contract_pda,
-                token_mint_pda.signer_seeds(),
-                rent_program,
-                system_program,
-                token_program,
-                decimals,
-            )?;
+            if token_mint_account.data_is_empty() {
+                // New mint account
+                // Check pda address
+                let token_mint_seeds = token_mint_seeds(&auction_id);
+                let token_mint_pda =
+                    SignerPda::new_checked(&token_mint_seeds, program_id, token_mint_account)?;
+
+                // Create ERC20 mint
+                create_mint_account(
+                    auction_owner_account,
+                    token_mint_account,
+                    contract_pda,
+                    token_mint_pda.signer_seeds(),
+                    rent_program,
+                    system_program,
+                    token_program,
+                    decimals,
+                )?;
+            } else {
+                // Existing mint account
+                // Check if auction owner is the mint authority of provided mint
+                assert_mint_authority(token_mint_account, auction_owner_account.key)?;
+
+                let transfer_authority_ix = spl_token::instruction::set_authority(
+                    &TOKEN_ID,
+                    token_mint_account.key,
+                    Some(contract_pda.key),
+                    spl_token::instruction::AuthorityType::MintTokens,
+                    auction_owner_account.key,
+                    &[auction_owner_account.key],
+                )?;
+
+                invoke(
+                    &transfer_authority_ix,
+                    &[
+                        token_program.to_owned(),
+                        contract_pda.to_owned(),
+                        auction_owner_account.to_owned(),
+                        token_mint_account.to_owned(),
+                    ],
+                )?;
+            }
 
             TokenConfig::Token(TokenData {
                 per_cycle_amount,

--- a/contract/src/processor/initialize_auction.rs
+++ b/contract/src/processor/initialize_auction.rs
@@ -340,7 +340,7 @@ pub fn initialize_auction(
             // Accounts (potentially) created in this instruction:
             //   token_mint_account
 
-            assert_token_mint_info(token_mint_account, &existing_account)?;
+            assert_token_mint_arg_consistency(token_mint_account, &existing_account)?;
 
             if token_mint_account.data_is_empty() {
                 // New mint account

--- a/contract/src/state.rs
+++ b/contract/src/state.rs
@@ -100,7 +100,7 @@ pub enum CreateTokenArgs {
     Token {
         decimals: u8,
         per_cycle_amount: u64,
-        existing_account: Option<Pubkey>,
+        existing_mint: Option<Pubkey>,
     },
 }
 

--- a/contract/src/state.rs
+++ b/contract/src/state.rs
@@ -97,7 +97,11 @@ pub enum CreateTokenArgs {
     ///
     /// The `per_cycle_amount` is the amount of tokens being auctioned off in
     /// each auction round.
-    Token { decimals: u8, per_cycle_amount: u64 },
+    Token {
+        decimals: u8,
+        per_cycle_amount: u64,
+        existing_account: Option<Pubkey>,
+    },
 }
 
 #[derive(Debug, Clone)]

--- a/contract/tests/process_close_auction_cycle.rs
+++ b/contract/tests/process_close_auction_cycle.rs
@@ -765,7 +765,7 @@ async fn test_process_close_idle_rapid_auction() {
             &auction_cycle_payer,
             auction_id,
             &auction_owner.keypair.pubkey(),
-            TokenType::Token,
+            TokenType::Nft,
         )
         .await
         .unwrap()

--- a/contract/tests/process_tokens.rs
+++ b/contract/tests/process_tokens.rs
@@ -13,6 +13,8 @@ use agsol_gold_contract::AuctionContractError;
 use agsol_gold_contract::ID as CONTRACT_ID;
 use agsol_testbench::{tokio, TestbenchError};
 
+// TODO: Try to reinitialize an auction with another closed auction's token mint
+
 #[tokio::test]
 async fn test_process_tokens() {
     let (mut testbench, auction_owner) = test_factory::testbench_setup().await.unwrap().unwrap();
@@ -35,6 +37,7 @@ async fn test_process_tokens() {
     let create_token_args = CreateTokenArgs::Token {
         decimals: 0,
         per_cycle_amount: 0,
+        existing_account: None,
     };
     let invalid_per_cycle_amount_error = initialize_new_auction_custom(
         &mut testbench,
@@ -119,6 +122,96 @@ async fn test_process_tokens() {
     );
 
     // Test after a bid was taken
+    let user_1 = TestUser::new(&mut testbench).await.unwrap().unwrap();
+
+    let bid_amount = 50_000_000;
+    place_bid_transaction(&mut testbench, auction_id, &user_1.keypair, bid_amount)
+        .await
+        .unwrap()
+        .unwrap();
+
+    // Closing cycle after bid
+    warp_to_cycle_end(&mut testbench, auction_id).await.unwrap();
+
+    close_cycle_transaction(
+        &mut testbench,
+        &auction_cycle_payer,
+        auction_id,
+        &auction_owner.keypair.pubkey(),
+        TokenType::Token,
+    )
+    .await
+    .unwrap()
+    .unwrap();
+
+    let token_mint = testbench
+        .get_mint_account(&token_mint_pubkey)
+        .await
+        .unwrap();
+    assert_eq!(token_mint.supply, 100);
+
+    let (token_holding_pubkey, _) = Pubkey::find_program_address(
+        &token_holding_seeds(&token_mint_pubkey, &user_1.keypair.pubkey()),
+        &CONTRACT_ID,
+    );
+    let token_holding = testbench
+        .get_token_account(&token_holding_pubkey)
+        .await
+        .unwrap();
+    assert_eq!(token_holding.amount, 100);
+    assert_eq!(token_holding.owner, user_1.keypair.pubkey());
+}
+
+#[tokio::test]
+async fn test_process_tokens_existing_mint() {
+    let (mut testbench, auction_owner) = test_factory::testbench_setup().await.unwrap().unwrap();
+
+    let auction_cycle_payer = TestUser::new(&mut testbench)
+        .await
+        .unwrap()
+        .unwrap()
+        .keypair;
+
+    let auction_id = [1; 32];
+    let auction_config = AuctionConfig {
+        cycle_period: 60,
+        encore_period: 1,
+        minimum_bid_amount: 50_000_000, // lamports
+        number_of_cycles: Some(1000),
+    };
+
+    let token_mint_pubkey = testbench
+        .create_mint(10, &auction_owner.keypair.pubkey())
+        .await
+        .unwrap()
+        .unwrap();
+
+    //  initialize auction with existing mint
+    let create_token_args = CreateTokenArgs::Token {
+        decimals: 0,
+        per_cycle_amount: 100,
+        existing_account: Some(token_mint_pubkey),
+    };
+    initialize_new_auction_custom(
+        &mut testbench,
+        &auction_owner.keypair,
+        &auction_config,
+        auction_id,
+        create_token_args,
+    )
+    .await
+    .unwrap()
+    .unwrap();
+
+    let mint_info = testbench
+        .get_mint_account(&token_mint_pubkey)
+        .await
+        .unwrap();
+
+    let contract_pda_pubkey = Pubkey::find_program_address(&contract_pda_seeds(), &CONTRACT_ID).0;
+    assert_eq!(mint_info.mint_authority.unwrap(), contract_pda_pubkey);
+
+    // Test token minting
     let user_1 = TestUser::new(&mut testbench).await.unwrap().unwrap();
 
     let bid_amount = 50_000_000;

--- a/contract/tests/process_tokens.rs
+++ b/contract/tests/process_tokens.rs
@@ -13,8 +13,6 @@ use agsol_gold_contract::AuctionContractError;
 use agsol_gold_contract::ID as CONTRACT_ID;
 use agsol_testbench::{tokio, TestbenchError};
 
-// TODO: Try to reinitialize an auction with another closed auction's token mint
-
 #[tokio::test]
 async fn test_process_tokens() {
     let (mut testbench, auction_owner) = test_factory::testbench_setup().await.unwrap().unwrap();

--- a/contract/tests/process_tokens.rs
+++ b/contract/tests/process_tokens.rs
@@ -35,7 +35,7 @@ async fn test_process_tokens() {
     let create_token_args = CreateTokenArgs::Token {
         decimals: 0,
         per_cycle_amount: 0,
-        existing_account: None,
+        existing_mint: None,
     };
     let invalid_per_cycle_amount_error = initialize_new_auction_custom(
         &mut testbench,
@@ -188,7 +188,7 @@ async fn test_process_tokens_existing_mint() {
     let create_token_args = CreateTokenArgs::Token {
         decimals: 0,
         per_cycle_amount: 100,
-        existing_account: Some(token_mint_pubkey),
+        existing_mint: Some(token_mint_pubkey),
     };
     initialize_new_auction_custom(
         &mut testbench,

--- a/gold-bot/src/main.rs
+++ b/gold-bot/src/main.rs
@@ -217,6 +217,9 @@ async fn close_cycle(
             .get_last_element()
             .map(|x| x.bidder_pubkey)
     };
+
+    let existing_token_mint = pool_record.get_token_mint_option().await;
+
     let close_auction_cycle_args = CloseAuctionCycleArgs {
         payer_pubkey: bot_keypair.pubkey(),
         auction_owner_pubkey: pool_record.root_state.auction_owner,
@@ -224,6 +227,7 @@ async fn close_cycle(
         auction_id: *auction_id,
         next_cycle_num: pool_record.root_state.status.current_auction_cycle,
         token_type,
+        existing_token_mint,
     };
     let close_auction_cycle_ix = close_auction_cycle(&close_auction_cycle_args);
 

--- a/gold-bot/src/pool_cache.rs
+++ b/gold-bot/src/pool_cache.rs
@@ -1,5 +1,5 @@
 use agsol_gold_contract::pda::{auction_cycle_state_seeds, auction_root_state_seeds};
-use agsol_gold_contract::state::{AuctionCycleState, AuctionId, AuctionRootState};
+use agsol_gold_contract::state::{AuctionCycleState, AuctionId, AuctionRootState, TokenConfig};
 use agsol_gold_contract::ID as GOLD_ID;
 use agsol_wasm_client::RpcClient;
 use solana_sdk::clock::UnixTimestamp;
@@ -76,6 +76,13 @@ impl PoolRecord {
             .get_and_deserialize_account_data(&cycle_pubkey)
             .await?;
         Ok(())
+    }
+
+    pub async fn get_token_mint_option(&mut self) -> Option<Pubkey> {
+        match self.root_state.token_config {
+            TokenConfig::Nft(_) => None,
+            TokenConfig::Token(ref token_data) => Some(token_data.mint),
+        }
     }
 
     /// Logs error appropriately, if unexpected error occurs then increments


### PR DESCRIPTION
## Description

Aims to resolve #53 .
Token auctions can now be created using existing mints too. This requires the auction owner to be the mint authority of this external mint and during initialization the mint authority is transferred to the contract PDA. Currently, there is no way to regain the mint authority from the contract PDA which may be a possible use case in the future. This change required no additional storage in any auction state accounts.

Tests and `gold-bot` were adjusted to the new parameters, and a new test was added to ensure the desired behaviour of the introduced new use case.

