### PR TITLE
Idle auctions are not filtered. Bid resets idle state.

### DIFF
--- a/contract/src/assertions.rs
+++ b/contract/src/assertions.rs
@@ -108,6 +108,7 @@ pub fn checked_debit_account(
 #[repr(C)]
 pub enum AuctionInteraction {
     Bid,
+    BidInactive,
     CloseCycle,
 }
 
@@ -131,6 +132,7 @@ pub fn check_status(
                 return Err(AuctionContractError::AuctionCycleEnded);
             }
         }
+        AuctionInteraction::BidInactive => return Ok(()),
         AuctionInteraction::CloseCycle => {
             if current_timestamp < cycle_state.end_time {
                 return Err(AuctionContractError::AuctionIsInProgress);

--- a/contract/src/instruction/factory/place_bid.rs
+++ b/contract/src/instruction/factory/place_bid.rs
@@ -19,6 +19,9 @@ pub fn place_bid(args: &PlaceBidArgs) -> Instruction {
         &auction_cycle_state_seeds(&auction_root_state_pubkey, &args.cycle_number.to_le_bytes()),
         &crate::ID,
     );
+    let (auction_pool_pubkey, _) = Pubkey::find_program_address(&auction_pool_seeds(), &crate::ID);
+    let (secondary_pool_pubkey, _) =
+        Pubkey::find_program_address(&secondary_pool_seeds(), &crate::ID);
 
     let top_bidder = if let Some(bidder) = args.top_bidder_pubkey {
         bidder
@@ -32,6 +35,8 @@ pub fn place_bid(args: &PlaceBidArgs) -> Instruction {
         AccountMeta::new(auction_root_state_pubkey, false),
         AccountMeta::new(auction_cycle_state_pubkey, false),
         AccountMeta::new(top_bidder, false),
+        AccountMeta::new(auction_pool_pubkey, false),
+        AccountMeta::new(secondary_pool_pubkey, false),
         AccountMeta::new_readonly(SYS_ID, false),
     ];
 


### PR DESCRIPTION
## Description

Idle auctions are no longer filtered, they are moved into the secondary pool instead without any flag changes. Bids on such auctions are always allowed regardless of auction cycle end time, and they reactivate the auction; they are moved back to the primary auction pool and sets the cycle end time as if cycle has just started (full cycle_period added to current time).