### PR TITLE
ModifyAuction instruction added

### DIFF
--- a/contract/Cargo.toml
+++ b/contract/Cargo.toml
@@ -17,7 +17,7 @@ client = []
 
 [dependencies]
 agsol-borsh-schema = "0.0.1"
-agsol-common = { version = "0.2.0", features = ["derive"] }
+agsol-common = { path = "../../agora-solana/agsol-common", features = ["derive"] }
 borsh = "0.9.0"
 borsh-derive = "0.9.0"
 agsol-token-metadata = { version = "0.0.0-alpha", features = ["no-entrypoint"] }

--- a/contract/src/error.rs
+++ b/contract/src/error.rs
@@ -36,6 +36,8 @@ pub enum AuctionContractError {
     InvalidPerCycleAmount = 527,      // 20f
     InvalidCyclePeriod = 528,         // 210
     AuctionIdNotAscii = 529,          // 211
+    StringTooLong = 531,              // 213
+    InvalidEncorePeriod = 532,        // 214
 }
 
 impl From<AuctionContractError> for ProgramError {

--- a/contract/src/instruction/factory/mod.rs
+++ b/contract/src/instruction/factory/mod.rs
@@ -5,6 +5,7 @@ mod delete_auction;
 mod filter_auction;
 mod initialize_auction;
 mod initialize_contract;
+mod modify_auction;
 mod place_bid;
 mod reallocate_pool;
 mod verify_auction;
@@ -16,6 +17,7 @@ pub use delete_auction::*;
 pub use filter_auction::*;
 pub use initialize_auction::*;
 pub use initialize_contract::*;
+pub use modify_auction::*;
 pub use place_bid::*;
 pub use reallocate_pool::*;
 pub use verify_auction::*;
@@ -23,7 +25,8 @@ pub use verify_auction::*;
 use super::AuctionInstruction;
 use crate::pda::*;
 use crate::state::{
-    AuctionConfig, AuctionDescription, AuctionId, AuctionName, CreateTokenArgs, TokenType,
+    AuctionConfig, AuctionDescription, AuctionId, AuctionName, CreateTokenArgs, ModifyAuctionData,
+    TokenType,
 };
 use agsol_token_metadata::instruction::CreateMetadataAccountArgs;
 use agsol_token_metadata::state::EDITION_MARKER_BIT_SIZE;

--- a/contract/src/instruction/factory/modify_auction.rs
+++ b/contract/src/instruction/factory/modify_auction.rs
@@ -1,0 +1,28 @@
+use super::*;
+
+pub struct ModifyAuctionArgs {
+    pub auction_owner_pubkey: Pubkey,
+    pub auction_id: AuctionId,
+    pub modify_data: ModifyAuctionData,
+}
+
+pub fn modify_auction(args: &ModifyAuctionArgs) -> Instruction {
+    let (auction_root_state_pubkey, _) =
+        Pubkey::find_program_address(&auction_root_state_seeds(&args.auction_id), &crate::ID);
+
+    let accounts = vec![
+        AccountMeta::new(args.auction_owner_pubkey, true),
+        AccountMeta::new(auction_root_state_pubkey, false),
+    ];
+
+    let instruction = AuctionInstruction::ModifyAuction {
+        id: args.auction_id,
+        modify_data: args.modify_data.clone(),
+    };
+
+    Instruction {
+        program_id: crate::ID,
+        accounts,
+        data: instruction.try_to_vec().unwrap(),
+    }
+}

--- a/contract/src/instruction/mod.rs
+++ b/contract/src/instruction/mod.rs
@@ -1,7 +1,9 @@
 #[cfg(feature = "client")]
 pub mod factory;
 
-use crate::state::{AuctionConfig, AuctionDescription, AuctionId, AuctionName, CreateTokenArgs};
+use crate::state::{
+    AuctionConfig, AuctionDescription, AuctionId, AuctionName, CreateTokenArgs, ModifyAuctionData,
+};
 use borsh::{BorshDeserialize, BorshSerialize};
 use solana_program::clock::UnixTimestamp;
 use solana_program::pubkey::Pubkey;
@@ -55,5 +57,9 @@ pub enum AuctionInstruction {
     },
     ReallocatePool {
         new_max_auction_num: u32,
+    },
+    ModifyAuction {
+        id: AuctionId,
+        modify_data: ModifyAuctionData,
     },
 }

--- a/contract/src/processor/initialize_auction.rs
+++ b/contract/src/processor/initialize_auction.rs
@@ -142,6 +142,11 @@ pub fn initialize_auction(
         return Err(AuctionContractError::AuctionIdNotAscii.into());
     }
 
+    // Check if encore period is non-negative
+    if auction_config.encore_period < 0 {
+        return Err(AuctionContractError::InvalidEncorePeriod.into());
+    }
+
     // Check auction start time (if provided)
     let clock = Clock::get()?;
     if let Some(start_time) = auction_start_timestamp {

--- a/contract/src/processor/mod.rs
+++ b/contract/src/processor/mod.rs
@@ -6,6 +6,7 @@ mod delete_auction;
 mod filter_auction;
 mod initialize_auction;
 mod initialize_contract;
+mod modify_auction;
 mod reallocate_pool;
 mod verify_auction;
 
@@ -108,5 +109,8 @@ pub fn process(
         AuctionInstruction::ReallocatePool {
             new_max_auction_num,
         } => reallocate_pool::reallocate_pool(program_id, accounts, new_max_auction_num),
+        AuctionInstruction::ModifyAuction { id, modify_data } => {
+            modify_auction::process_modify_auction(program_id, accounts, id, modify_data)
+        }
     }
 }

--- a/contract/src/processor/modify_auction.rs
+++ b/contract/src/processor/modify_auction.rs
@@ -1,0 +1,50 @@
+use super::*;
+
+pub fn process_modify_auction(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    auction_id: AuctionId,
+    modify_data: ModifyAuctionData,
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+    let auction_owner_account = next_account_info(account_info_iter)?;
+    let auction_root_state_account = next_account_info(account_info_iter)?;
+
+    if !auction_owner_account.is_signer {
+        msg!("owner signature is missing");
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+
+    // Check pda addresses
+    SignerPda::check_owner(
+        &auction_root_state_seeds(&auction_id),
+        program_id,
+        program_id,
+        auction_root_state_account,
+    )?;
+
+    // Check auction owner account
+    let mut auction_root_state = AuctionRootState::read(auction_root_state_account)?;
+    if auction_owner_account.key != &auction_root_state.auction_owner {
+        return Err(AuctionContractError::AuctionOwnerMismatch.into());
+    }
+
+    if let Some(new_description) = modify_data.new_description {
+        auction_root_state.description.description = new_description;
+    }
+
+    if let Some(new_socials) = modify_data.new_socials {
+        auction_root_state.description.socials = new_socials;
+    }
+
+    if let Some(new_encore_period) = modify_data.new_encore_period {
+        if new_encore_period < 0 {
+            return Err(AuctionContractError::InvalidEncorePeriod.into());
+        }
+        auction_root_state.auction_config.encore_period = new_encore_period;
+    }
+
+    auction_root_state.write(auction_root_state_account)?;
+
+    Ok(())
+}

--- a/contract/src/state.rs
+++ b/contract/src/state.rs
@@ -182,6 +182,16 @@ pub struct AuctionPool {
     pub pool: Vec<AuctionId>,
 }
 
+/// Contains which information to modify on a ModifyAuction call.
+/// If a member is set to `None` it will be unchanged.
+#[repr(C)]
+#[derive(BorshSchema, BorshDeserialize, BorshSerialize, Debug, Clone)]
+pub struct ModifyAuctionData {
+    pub new_description: Option<DescriptionString>,
+    pub new_socials: Option<SocialsVec>,
+    pub new_encore_period: Option<UnixTimestamp>,
+}
+
 impl AuctionPool {
     pub fn max_serialized_len(n: usize) -> Option<usize> {
         let mul_result = AuctionId::MAX_SERIALIZED_LEN.checked_mul(n);

--- a/contract/tests/process_modify_auction.rs
+++ b/contract/tests/process_modify_auction.rs
@@ -1,0 +1,138 @@
+#![cfg(feature = "test-bpf")]
+mod test_factory;
+use test_factory::*;
+
+use agsol_gold_contract::pda::*;
+use agsol_gold_contract::state::*;
+use agsol_gold_contract::ID as CONTRACT_ID;
+use agsol_testbench::tokio;
+use solana_program::pubkey::Pubkey;
+
+#[tokio::test]
+async fn test_process_verify_auction() {
+    let (mut testbench, auction_owner) = test_factory::testbench_setup().await.unwrap().unwrap();
+
+    let auction_id = [2; 32];
+    let auction_config = AuctionConfig {
+        cycle_period: 100,
+        encore_period: 30,
+        minimum_bid_amount: 50_000_000,
+        number_of_cycles: Some(10),
+    };
+
+    initialize_new_auction(
+        &mut testbench,
+        &auction_owner.keypair,
+        &auction_config,
+        auction_id,
+        TokenType::Nft,
+    )
+    .await
+    .unwrap()
+    .unwrap();
+
+    // check state account
+    let (auction_root_state_pubkey, _) =
+        Pubkey::find_program_address(&auction_root_state_seeds(&auction_id), &CONTRACT_ID);
+
+    // modify auction description
+    let modify_data = ModifyAuctionData {
+        new_description: Some(
+            "This is quite the description, definitely changed from the original!"
+                .try_into()
+                .unwrap(),
+        ),
+        new_socials: None,
+        new_encore_period: None,
+    };
+
+    let balance_change = modify_auction_transaction(
+        &mut testbench,
+        auction_id,
+        &auction_owner.keypair,
+        modify_data.clone(),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+
+    let auction_root_state = testbench
+        .get_and_deserialize_account_data::<AuctionRootState>(&auction_root_state_pubkey)
+        .await
+        .unwrap();
+    assert_eq!(
+        auction_root_state.description.description.clone_contents(),
+        modify_data.new_description.unwrap().clone_contents()
+    );
+
+    assert_eq!(-balance_change as u64, TRANSACTION_FEE);
+
+    // modify socials
+    let modify_data = ModifyAuctionData {
+        new_description: None,
+        new_socials: Some(
+            vec![
+                "an-original-socials-link.ayo".try_into().unwrap(),
+                "and-another-one.dj".try_into().unwrap(),
+            ]
+            .try_into()
+            .unwrap(),
+        ),
+        new_encore_period: None,
+    };
+
+    modify_auction_transaction(
+        &mut testbench,
+        auction_id,
+        &auction_owner.keypair,
+        modify_data.clone(),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+
+    let auction_root_state = testbench
+        .get_and_deserialize_account_data::<AuctionRootState>(&auction_root_state_pubkey)
+        .await
+        .unwrap();
+
+    for (i, socials_string) in auction_root_state
+        .description
+        .socials
+        .contents()
+        .iter()
+        .enumerate()
+    {
+        assert_eq!(
+            socials_string.clone_contents(),
+            modify_data.new_socials.as_ref().unwrap().contents()[i].clone_contents()
+        );
+    }
+
+    // modify socials
+    let modify_data = ModifyAuctionData {
+        new_description: None,
+        new_socials: None,
+        new_encore_period: Some(20000),
+    };
+
+    modify_auction_transaction(
+        &mut testbench,
+        auction_id,
+        &auction_owner.keypair,
+        modify_data.clone(),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+
+    let auction_root_state = testbench
+        .get_and_deserialize_account_data::<AuctionRootState>(&auction_root_state_pubkey)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        auction_root_state.auction_config.encore_period,
+        modify_data.new_encore_period.unwrap()
+    );
+}

--- a/contract/tests/test_factory.rs
+++ b/contract/tests/test_factory.rs
@@ -18,7 +18,7 @@ use agsol_gold_contract::pda::{
 };
 use agsol_gold_contract::state::{
     AuctionConfig, AuctionCycleState, AuctionDescription, AuctionRootState, BidData,
-    CreateTokenArgs, NftData, TokenConfig, TokenData, TokenType,
+    CreateTokenArgs, ModifyAuctionData, NftData, TokenConfig, TokenData, TokenType,
 };
 use agsol_gold_contract::AuctionContractError;
 use agsol_gold_contract::ID as CONTRACT_ID;
@@ -294,6 +294,25 @@ pub async fn verify_auction_transaction(
 
     testbench
         .process_transaction(&[verify_instruction], contract_admin_keypair, None)
+        .await
+        .map(|transaction_result| transaction_result.map_err(to_auction_error))
+}
+
+pub async fn modify_auction_transaction(
+    testbench: &mut Testbench,
+    auction_id: [u8; 32],
+    auction_owner_keypair: &Keypair,
+    modify_data: ModifyAuctionData,
+) -> AuctionTransactionResult {
+    let modify_args = ModifyAuctionArgs {
+        auction_owner_pubkey: auction_owner_keypair.pubkey(),
+        auction_id,
+        modify_data,
+    };
+    let modify_instruction = modify_auction(&modify_args);
+
+    testbench
+        .process_transaction(&[modify_instruction], auction_owner_keypair, None)
         .await
         .map(|transaction_result| transaction_result.map_err(to_auction_error))
 }


### PR DESCRIPTION
## Description

Aims to resolve #52 .
Added a new instruction `ModifyAuction` which enables the auction owner to change some settings, namely the description, the socials and the encore period of the auction. This list can later be expanded.

The contract tests require the query of a `MaxLenString`'s contents which requires the merge of [this pull request](https://github.com/agoraxyz/agora-solana/pull/22) in the `agora-solana` repository.