### PR TITLE
Protocol fee can be adjusted by contract admin

### DIFF
--- a/contract/src/error.rs
+++ b/contract/src/error.rs
@@ -37,6 +37,7 @@ pub enum AuctionContractError {
     InvalidCyclePeriod = 528,         // 210
     AuctionIdNotAscii = 529,          // 211
     TokenAuctionInconsistency = 530,  // 212
+    InvalidProtocolFee = 531,         // 213
 }
 
 impl From<AuctionContractError> for ProgramError {

--- a/contract/src/instruction/factory/claim_funds.rs
+++ b/contract/src/instruction/factory/claim_funds.rs
@@ -22,12 +22,16 @@ pub fn claim_funds(args: &ClaimFundsArgs) -> Instruction {
     let (contract_bank_pubkey, _) =
         Pubkey::find_program_address(&contract_bank_seeds(), &crate::ID);
 
+    let (protocol_fee_state_pubkey, _) =
+        Pubkey::find_program_address(&protocol_fee_state_seeds(), &crate::ID);
+
     let accounts = vec![
         AccountMeta::new(args.auction_owner_pubkey, true),
         AccountMeta::new(auction_bank_pubkey, false),
         AccountMeta::new(auction_root_state_pubkey, false),
         AccountMeta::new(auction_cycle_state_pubkey, false),
         AccountMeta::new(contract_bank_pubkey, false),
+        AccountMeta::new_readonly(protocol_fee_state_pubkey, false),
     ];
 
     let instruction = AuctionInstruction::ClaimFunds {

--- a/contract/src/instruction/factory/close_auction_cycle.rs
+++ b/contract/src/instruction/factory/close_auction_cycle.rs
@@ -11,8 +11,6 @@ pub struct CloseAuctionCycleArgs {
 }
 
 pub fn close_auction_cycle(args: &CloseAuctionCycleArgs) -> Instruction {
-    let (auction_bank_pubkey, _) =
-        Pubkey::find_program_address(&auction_bank_seeds(&args.auction_id), &crate::ID);
     let (auction_root_state_pubkey, _) =
         Pubkey::find_program_address(&auction_root_state_seeds(&args.auction_id), &crate::ID);
     let (auction_pool_pubkey, _) = Pubkey::find_program_address(&auction_pool_seeds(), &crate::ID);
@@ -44,8 +42,6 @@ pub fn close_auction_cycle(args: &CloseAuctionCycleArgs) -> Instruction {
 
     let mut accounts = vec![
         AccountMeta::new(args.payer_pubkey, true),
-        AccountMeta::new(auction_bank_pubkey, false),
-        AccountMeta::new(args.auction_owner_pubkey, false),
         AccountMeta::new(auction_pool_pubkey, false),
         AccountMeta::new(secondary_pool_pubkey, false),
         AccountMeta::new(auction_root_state_pubkey, false),

--- a/contract/src/instruction/factory/delete_auction.rs
+++ b/contract/src/instruction/factory/delete_auction.rs
@@ -24,6 +24,9 @@ pub fn delete_auction(args: &DeleteAuctionArgs) -> Instruction {
     let (auction_root_state_pubkey, _) =
         Pubkey::find_program_address(&auction_root_state_seeds(&args.auction_id), &crate::ID);
 
+    let (protocol_fee_state_pubkey, _) =
+        Pubkey::find_program_address(&protocol_fee_state_seeds(), &crate::ID);
+
     let top_bidder = if let Some(bidder) = args.top_bidder_pubkey {
         bidder
     } else {
@@ -38,6 +41,7 @@ pub fn delete_auction(args: &DeleteAuctionArgs) -> Instruction {
         AccountMeta::new(contract_bank_pubkey, false),
         AccountMeta::new(auction_pool_pubkey, false),
         AccountMeta::new(secondary_pool_pubkey, false),
+        AccountMeta::new_readonly(protocol_fee_state_pubkey, false),
     ];
 
     let cycles_to_include = std::cmp::min(args.current_auction_cycle, args.num_of_cycles_to_delete);

--- a/contract/src/instruction/factory/mod.rs
+++ b/contract/src/instruction/factory/mod.rs
@@ -7,6 +7,7 @@ mod initialize_auction;
 mod initialize_contract;
 mod place_bid;
 mod reallocate_pool;
+mod set_protocol_fee;
 mod verify_auction;
 
 pub use admin_withdraw::*;
@@ -18,6 +19,7 @@ pub use initialize_auction::*;
 pub use initialize_contract::*;
 pub use place_bid::*;
 pub use reallocate_pool::*;
+pub use set_protocol_fee::*;
 pub use verify_auction::*;
 
 use super::AuctionInstruction;

--- a/contract/src/instruction/factory/set_protocol_fee.rs
+++ b/contract/src/instruction/factory/set_protocol_fee.rs
@@ -1,0 +1,31 @@
+use super::*;
+
+pub struct SetProtocolFeeArgs {
+    pub contract_admin_pubkey: Pubkey,
+    pub new_fee: u8,
+}
+
+pub fn set_protocol_fee(args: &SetProtocolFeeArgs) -> Instruction {
+    let (contract_bank_pubkey, _) =
+        Pubkey::find_program_address(&contract_bank_seeds(), &crate::ID);
+
+    let (protocol_fee_state_pubkey, _) =
+        Pubkey::find_program_address(&protocol_fee_state_seeds(), &crate::ID);
+
+    let accounts = vec![
+        AccountMeta::new(args.contract_admin_pubkey, true),
+        AccountMeta::new_readonly(contract_bank_pubkey, false),
+        AccountMeta::new(protocol_fee_state_pubkey, false),
+        AccountMeta::new_readonly(SYS_ID, false),
+    ];
+
+    let instruction = AuctionInstruction::SetProtocolFee {
+        new_fee: args.new_fee,
+    };
+
+    Instruction {
+        program_id: crate::ID,
+        accounts,
+        data: instruction.try_to_vec().unwrap(),
+    }
+}

--- a/contract/src/instruction/mod.rs
+++ b/contract/src/instruction/mod.rs
@@ -56,4 +56,7 @@ pub enum AuctionInstruction {
     ReallocatePool {
         new_max_auction_num: u32,
     },
+    SetProtocolFee {
+        new_fee: u8,
+    },
 }

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -54,6 +54,8 @@ pub const UNIVERSAL_BID_FLOOR: u64 = 50_000_000;
 pub const MIN_CYCLE_PERIOD: UnixTimestamp = 60; // one minute
 /// Minimum length of an auction cycle period in seconds.
 pub const MAX_CYCLE_PERIOD: UnixTimestamp = 31_557_600; // one year
+/// Default protocol fee in thousandths for all claimed funds.
+pub const DEFAULT_PROTOCOL_FEE: u8 = 50; // 5 %
 
 /// The recommended number of state accounts that can be safely wiped via a
 /// `DeleteAuction` contract call without exceeding the allotted compute units.

--- a/contract/src/pda/mod.rs
+++ b/contract/src/pda/mod.rs
@@ -15,6 +15,10 @@ pub fn secondary_pool_seeds<'a>() -> [&'a [u8]; 1] {
     [b"gold_secondary_pool"]
 }
 
+pub fn protocol_fee_state_seeds<'a>() -> [&'a [u8]; 1] {
+    [b"gold_protocol_fee"]
+}
+
 pub fn auction_bank_seeds(auction_id: &[u8]) -> [&[u8]; 2] {
     [b"gold_auction_bank", auction_id]
 }

--- a/contract/src/processor/claim_funds.rs
+++ b/contract/src/processor/claim_funds.rs
@@ -1,4 +1,6 @@
 use super::*;
+use crate::DEFAULT_PROTOCOL_FEE;
+
 use solana_program::rent::Rent;
 
 pub fn process_claim_funds(
@@ -13,6 +15,7 @@ pub fn process_claim_funds(
     let auction_root_state_account = next_account_info(account_info_iter)?;
     let auction_cycle_state_account = next_account_info(account_info_iter)?;
     let contract_bank_account = next_account_info(account_info_iter)?;
+    let protocol_fee_state_account = next_account_info(account_info_iter)?;
 
     if !auction_owner_account.is_signer {
         msg!("admin signature is missing");
@@ -92,6 +95,7 @@ pub fn process_claim_funds(
         auction_owner_account,
         auction_bank_account,
         contract_bank_account,
+        protocol_fee_state_account,
     )?;
 
     // Update available funds in the root state
@@ -108,13 +112,22 @@ pub fn claim_lamports(
     auction_owner_account: &AccountInfo<'_>,
     auction_bank_account: &AccountInfo<'_>,
     contract_bank_account: &AccountInfo<'_>,
-) -> Result<(), AuctionContractError> {
+    protocol_fee_state_account: &AccountInfo<'_>,
+) -> Result<(), ProgramError> {
+    let fee_state =
+        ProtocolFeeState::read(protocol_fee_state_account).unwrap_or(ProtocolFeeState {
+            fee: DEFAULT_PROTOCOL_FEE,
+        });
+
+    let mut fee_float: f64 = fee_state.fee.into();
+    // convert into multiplier from thousandths
+    fee_float /= 1_000.0;
+
     // This may not be precise because of integer rounding but it is more simple
-    // Error is at most 19 lamports which is negligible
-    let lamport_divided = amount / 20;
-    let auction_owner_share = lamport_divided * 19;
-    let contract_bank_share = amount
-        .checked_sub(auction_owner_share)
+    let amount_float = amount as f64;
+    let contract_bank_share = (amount_float * fee_float) as u64;
+    let auction_owner_share = amount
+        .checked_sub(contract_bank_share)
         .ok_or(AuctionContractError::ArithmeticError)?;
 
     checked_credit_account(contract_bank_account, contract_bank_share)?;
@@ -123,5 +136,7 @@ pub fn claim_lamports(
     checked_debit_account(
         auction_bank_account,
         auction_owner_share + contract_bank_share,
-    )
+    )?;
+
+    Ok(())
 }

--- a/contract/src/processor/delete_auction.rs
+++ b/contract/src/processor/delete_auction.rs
@@ -16,6 +16,7 @@ pub fn process_delete_auction(
     let contract_bank_account = next_account_info(account_info_iter)?; // 5
     let auction_pool_account = next_account_info(account_info_iter)?; // 6
     let secondary_pool_account = next_account_info(account_info_iter)?; // 7
+    let protocol_fee_state_account = next_account_info(account_info_iter)?; // 8
 
     if !auction_owner_account.is_signer {
         msg!("Auction owner signature is missing");
@@ -127,6 +128,7 @@ pub fn process_delete_auction(
         auction_owner_account,
         auction_bank_account,
         contract_bank_account,
+        protocol_fee_state_account,
     )?;
 
     deallocate_state(auction_root_state_account, auction_owner_account)?;

--- a/contract/src/processor/mod.rs
+++ b/contract/src/processor/mod.rs
@@ -7,6 +7,7 @@ mod filter_auction;
 mod initialize_auction;
 mod initialize_contract;
 mod reallocate_pool;
+mod set_protocol_fee;
 mod verify_auction;
 
 use crate::assertions::*;
@@ -108,5 +109,8 @@ pub fn process(
         AuctionInstruction::ReallocatePool {
             new_max_auction_num,
         } => reallocate_pool::reallocate_pool(program_id, accounts, new_max_auction_num),
+        AuctionInstruction::SetProtocolFee { new_fee } => {
+            set_protocol_fee::process_set_protocol_fee(program_id, accounts, new_fee)
+        }
     }
 }

--- a/contract/src/processor/set_protocol_fee.rs
+++ b/contract/src/processor/set_protocol_fee.rs
@@ -1,0 +1,63 @@
+use super::*;
+
+pub fn process_set_protocol_fee(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    new_fee: u8,
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+    let contract_admin_account = next_account_info(account_info_iter)?;
+    let contract_bank_account = next_account_info(account_info_iter)?;
+    let protocol_fee_state_account = next_account_info(account_info_iter)?;
+    let system_program = next_account_info(account_info_iter)?;
+
+    if !contract_admin_account.is_signer {
+        msg!("admin signature is missing");
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+
+    assert_system_program(system_program.key)?;
+
+    // Check pda addresses
+    SignerPda::check_owner(
+        &contract_bank_seeds(),
+        program_id,
+        program_id,
+        contract_bank_account,
+    )?;
+
+    let fee_state_seeds = protocol_fee_state_seeds();
+    let fee_account_pda =
+        SignerPda::new_checked(&fee_state_seeds, program_id, protocol_fee_state_account)?;
+
+    // Check contract admin authority
+    let contract_bank_state = ContractBankState::read(contract_bank_account)?;
+    if contract_admin_account.key != &contract_bank_state.contract_admin {
+        return Err(AuctionContractError::ContractAdminMismatch.into());
+    }
+
+    // Check fee account owner or create it if necessary
+    let mut fee_state = if protocol_fee_state_account.data_is_empty() {
+        create_state_account(
+            contract_admin_account,
+            protocol_fee_state_account,
+            fee_account_pda.signer_seeds(),
+            program_id,
+            system_program,
+            ProtocolFeeState::MAX_SERIALIZED_LEN,
+        )?;
+        ProtocolFeeState { fee: 50 }
+    } else {
+        assert_owner(protocol_fee_state_account, program_id)?;
+        ProtocolFeeState::read(protocol_fee_state_account)?
+    };
+
+    if new_fee > 50 {
+        return Err(AuctionContractError::InvalidProtocolFee.into());
+    }
+
+    fee_state.fee = new_fee;
+    fee_state.write(protocol_fee_state_account)?;
+
+    Ok(())
+}

--- a/contract/src/state.rs
+++ b/contract/src/state.rs
@@ -240,6 +240,15 @@ pub struct ContractBankState {
     pub withdraw_authority: Pubkey,
 }
 
+#[repr(C)]
+#[derive(BorshDeserialize, BorshSerialize, AccountState, MaxSerializedLen, Debug, Clone)]
+pub struct ProtocolFeeState {
+    /// The protocol fee collected on all claimed funds.
+    ///
+    /// Expressed in thousandths, max 5% (50)
+    pub fee: u8,
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/contract/tests/process_set_protocol_fee.rs
+++ b/contract/tests/process_set_protocol_fee.rs
@@ -1,0 +1,133 @@
+#![cfg(feature = "test-bpf")]
+mod test_factory;
+use test_factory::*;
+
+use agsol_gold_contract::pda::*;
+use agsol_gold_contract::state::*;
+use agsol_gold_contract::AuctionContractError;
+use agsol_gold_contract::ID as CONTRACT_ID;
+use agsol_testbench::tokio;
+use solana_program::pubkey::Pubkey;
+use solana_sdk::signature::Signer;
+
+#[tokio::test]
+async fn test_process_set_protocol_fee() {
+    let (mut testbench, auction_owner) = test_factory::testbench_setup().await.unwrap().unwrap();
+
+    let auction_id = [1; 32];
+    let auction_config = AuctionConfig {
+        cycle_period: 100,
+        encore_period: 30,
+        minimum_bid_amount: 50_000_000,
+        number_of_cycles: Some(10),
+    };
+
+    initialize_new_auction(
+        &mut testbench,
+        &auction_owner.keypair,
+        &auction_config,
+        auction_id,
+        TokenType::Nft,
+    )
+    .await
+    .unwrap()
+    .unwrap();
+
+    let payer = testbench.clone_payer();
+
+    let (protocol_fee_state_pubkey, _) =
+        Pubkey::find_program_address(&protocol_fee_state_seeds(), &CONTRACT_ID);
+    let (contract_bank_pubkey, _) =
+        Pubkey::find_program_address(&contract_bank_seeds(), &CONTRACT_ID);
+
+    // Set up some claimable funds to test on
+    let bid_amount = 50_000_000;
+    place_bid_transaction(
+        &mut testbench,
+        auction_id,
+        &auction_owner.keypair,
+        bid_amount,
+    )
+    .await
+    .unwrap()
+    .unwrap();
+
+    warp_to_cycle_end(&mut testbench, auction_id).await.unwrap();
+
+    close_cycle_transaction(
+        &mut testbench,
+        &payer,
+        auction_id,
+        &auction_owner.keypair.pubkey(),
+        TokenType::Nft,
+    )
+    .await
+    .unwrap()
+    .unwrap();
+
+    // Test claiming funds without setting protocol fee beforehand
+    let claim_amount = 10_000_000;
+    claim_and_assert_split(
+        &mut testbench,
+        auction_id,
+        &auction_owner.keypair,
+        claim_amount,
+        &contract_bank_pubkey,
+        &protocol_fee_state_pubkey,
+        50,
+    )
+    .await;
+
+    // Invalid use case
+    // Setting protocol fee to higher than 5%
+    let new_fee = 52;
+    let protocol_fee_too_damn_high_error =
+        set_protocol_fee_transaction(&mut testbench, &payer, new_fee)
+            .await
+            .unwrap()
+            .err()
+            .unwrap();
+
+    assert_eq!(
+        protocol_fee_too_damn_high_error,
+        AuctionContractError::InvalidProtocolFee
+    );
+
+    // Creating protocol fee account by setting it to the default value
+    let new_fee = 50;
+    set_protocol_fee_transaction(&mut testbench, &payer, new_fee)
+        .await
+        .unwrap()
+        .unwrap();
+
+    let claim_amount = 10_000_000;
+    claim_and_assert_split(
+        &mut testbench,
+        auction_id,
+        &auction_owner.keypair,
+        claim_amount,
+        &contract_bank_pubkey,
+        &protocol_fee_state_pubkey,
+        new_fee,
+    )
+    .await;
+
+    // Setting protocol fee to another value
+    let new_fee = 10;
+    set_protocol_fee_transaction(&mut testbench, &payer, new_fee)
+        .await
+        .unwrap()
+        .unwrap();
+
+    let claim_amount = 10_000_000;
+    claim_and_assert_split(
+        &mut testbench,
+        auction_id,
+        &auction_owner.keypair,
+        claim_amount,
+        &contract_bank_pubkey,
+        &protocol_fee_state_pubkey,
+        new_fee,
+    )
+    .await;
+}


### PR DESCRIPTION
## Description

Aims to resolve #60 .
Contract admin has the ability to set protocol fee. The fee cannot be set above 5% and is stored in thousandths (5% = 50). 

To maintain compatibility with previously deployed contract the protocol fee must be stored in a new account. Upon claiming funds an attempt is made to read the fee from this new account, however, there is a possibility that the account is not yet initialized, so in case of failure a `DEFAULT_PROTOCOL_FEE = 50` is used.