### PR TITLE
ClaimRewards added, CloseCycle reworked, all tests adjusted

### DIFF
--- a/contract/src/error.rs
+++ b/contract/src/error.rs
@@ -41,6 +41,7 @@ pub enum AuctionContractError {
     InvalidEncorePeriod = 532,        // 214
     InvalidProtocolFee = 533,         // 215
     RewardAlreadyClaimed = 534,       // 216
+    UnclaimedRewards = 535,           // 217
 }
 
 impl From<AuctionContractError> for ProgramError {

--- a/contract/src/error.rs
+++ b/contract/src/error.rs
@@ -40,6 +40,7 @@ pub enum AuctionContractError {
     StringTooLong = 531,              // 213
     InvalidEncorePeriod = 532,        // 214
     InvalidProtocolFee = 533,         // 215
+    RewardAlreadyClaimed = 534,       // 216
 }
 
 impl From<AuctionContractError> for ProgramError {

--- a/contract/src/instruction/factory/claim_funds.rs
+++ b/contract/src/instruction/factory/claim_funds.rs
@@ -2,7 +2,7 @@ use super::*;
 
 #[derive(BorshSchema, BorshSerialize, BorshDeserialize)]
 pub struct ClaimFundsArgs {
-    pub caller_pubkey: Pubkey,
+    pub payer_pubkey: Pubkey,
     pub auction_owner_pubkey: Pubkey,
     #[alias([u8; 32])]
     pub auction_id: AuctionId,
@@ -27,7 +27,7 @@ pub fn claim_funds(args: &ClaimFundsArgs) -> Instruction {
         Pubkey::find_program_address(&protocol_fee_state_seeds(), &crate::ID);
 
     let accounts = vec![
-        AccountMeta::new(args.caller_pubkey, true),
+        AccountMeta::new(args.payer_pubkey, true),
         AccountMeta::new(args.auction_owner_pubkey, false),
         AccountMeta::new(auction_bank_pubkey, false),
         AccountMeta::new(auction_root_state_pubkey, false),

--- a/contract/src/instruction/factory/claim_rewards.rs
+++ b/contract/src/instruction/factory/claim_rewards.rs
@@ -24,7 +24,7 @@ pub fn claim_rewards(args: &ClaimRewardsArgs) -> Instruction {
     let mut accounts = vec![
         AccountMeta::new(args.payer_pubkey, true),
         AccountMeta::new_readonly(args.top_bidder_pubkey, false),
-        AccountMeta::new_readonly(auction_root_state_pubkey, false),
+        AccountMeta::new(auction_root_state_pubkey, false),
         AccountMeta::new(auction_cycle_state_pubkey, false),
         AccountMeta::new_readonly(contract_pda, false),
         AccountMeta::new_readonly(RENT_ID, false),

--- a/contract/src/instruction/factory/mod.rs
+++ b/contract/src/instruction/factory/mod.rs
@@ -1,5 +1,6 @@
 mod admin_withdraw;
 mod claim_funds;
+mod claim_rewards;
 mod close_auction_cycle;
 mod delete_auction;
 mod filter_auction;
@@ -13,6 +14,7 @@ mod verify_auction;
 
 pub use admin_withdraw::*;
 pub use claim_funds::*;
+pub use claim_rewards::*;
 pub use close_auction_cycle::*;
 pub use delete_auction::*;
 pub use filter_auction::*;

--- a/contract/src/instruction/mod.rs
+++ b/contract/src/instruction/mod.rs
@@ -46,6 +46,10 @@ pub enum AuctionInstruction {
         id: AuctionId,
         amount: u64,
     },
+    ClaimRewards {
+        id: AuctionId,
+        cycle_number: u64,
+    },
     VerifyAuction {
         id: AuctionId,
     },

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -39,7 +39,7 @@ pub const MAX_SOCIALS_NUM: usize = 5;
 /// Additional bytes allocated to the
 /// [`AuctionRootState`](state::AuctionRootState) account for future
 /// development.
-pub const EXTRA_ROOT_STATE_BYTES: usize = 32;
+pub const EXTRA_ROOT_STATE_BYTES: usize = 30;
 /// Allowed time period for an auction to go without a bid placed on it before
 /// it is automatically filtered at cycle closing.
 /// Currently set for a week of inactivity.

--- a/contract/src/processor/claim_funds.rs
+++ b/contract/src/processor/claim_funds.rs
@@ -10,7 +10,7 @@ pub fn process_claim_funds(
     amount: u64,
 ) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
-    let caller_account = next_account_info(account_info_iter)?;
+    let payer_account = next_account_info(account_info_iter)?;
     let auction_owner_account = next_account_info(account_info_iter)?;
     let auction_bank_account = next_account_info(account_info_iter)?;
     let auction_root_state_account = next_account_info(account_info_iter)?;
@@ -18,8 +18,8 @@ pub fn process_claim_funds(
     let contract_bank_account = next_account_info(account_info_iter)?;
     let protocol_fee_state_account = next_account_info(account_info_iter)?;
 
-    if !caller_account.is_signer {
-        msg!("caller signature is missing");
+    if !payer_account.is_signer {
+        msg!("payer signature is missing");
         return Err(ProgramError::MissingRequiredSignature);
     }
 

--- a/contract/src/processor/claim_rewards.rs
+++ b/contract/src/processor/claim_rewards.rs
@@ -1,0 +1,431 @@
+use super::*;
+
+use agsol_token_metadata::state::Data as MetadataStateData;
+use std::str::FromStr;
+
+const METADATA_DATA_START_POS: usize = 65;
+
+// NOTE: The user can be made to pay for this account's creation by locking its fee besides their bid at the time of bidding
+//   and using this locked fee now.
+// NOTE: With the current calculation method we may scam the auction owner with at most 19 lamports due to rounding.
+//   This may be improved.
+
+// NOTE: We might introduce a "grace period" in which the user can not bid before initiating a new auction
+//   in case they wanted to bid in the last second, so that they do not bid on the next auctioned asset accidentally
+/// Closes auction cycle
+///
+/// Creates holding account for the won asset for the user with the highest bid.
+/// The cost of this account's creation is deducted from the highest bid.
+///
+/// Then, distributes the deducted highest bid in the following fashion:
+///
+/// - 95% to the auction owner
+///
+/// - 5% to the contract admin
+pub fn process_claim_rewards(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    auction_id: AuctionId,
+    cycle_number: u64,
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+    // misc
+    let payer_account = next_account_info(account_info_iter)?;
+
+    // user accounts
+    let top_bidder_account = next_account_info(account_info_iter)?;
+
+    // contract state accounts
+    let auction_root_state_account = next_account_info(account_info_iter)?;
+    let auction_cycle_state_account = next_account_info(account_info_iter)?;
+
+    // contract signer pda
+    let contract_pda = next_account_info(account_info_iter)?;
+
+    // external programs
+    let rent_program = next_account_info(account_info_iter)?;
+    let system_program = next_account_info(account_info_iter)?;
+    let token_program = next_account_info(account_info_iter)?;
+
+    if !payer_account.is_signer {
+        msg!("payer signature is missing");
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+
+    // Check cross-program invocation addresses
+    assert_rent_program(rent_program.key)?;
+    assert_system_program(system_program.key)?;
+    assert_token_program(token_program.key)?;
+
+    // Check account ownership
+    // User accounts:
+    //   payer_account
+    //   top_bidder_account
+    // Pda accounts:
+    //   contract_pda
+    // Accounts created in this instruction:
+    //   next_auction_cycle_state_account
+
+    // check root and cycle states
+    SignerPda::check_owner(
+        &auction_root_state_seeds(&auction_id),
+        program_id,
+        program_id,
+        auction_root_state_account,
+    )?;
+
+    let cycle_num_bytes = cycle_number.to_le_bytes();
+
+    SignerPda::check_owner(
+        &auction_cycle_state_seeds(auction_root_state_account.key, &cycle_num_bytes),
+        program_id,
+        program_id,
+        auction_cycle_state_account,
+    )?;
+
+    let contract_pda_seeds = contract_pda_seeds();
+    let contract_signer_pda =
+        SignerPda::new_checked(&contract_pda_seeds, program_id, contract_pda)?;
+
+    let mut auction_cycle_state = AuctionCycleState::read(auction_cycle_state_account)?;
+
+    // Check auction status (frozen, active, able to end cycle)
+    let clock = Clock::get()?;
+    let current_timestamp = clock.unix_timestamp;
+
+    if current_timestamp < auction_cycle_state.end_time {
+        return Err(AuctionContractError::AuctionIsInProgress.into());
+    }
+    if auction_cycle_state.end_time == 0 {
+        return Err(AuctionContractError::RewardAlreadyClaimed.into());
+    }
+
+    // Check top bidder account
+    let most_recent_bid_option = auction_cycle_state.bid_history.get_last_element();
+    if let Some(most_recent_bid) = most_recent_bid_option {
+        if top_bidder_account.key != &most_recent_bid.bidder_pubkey {
+            return Err(AuctionContractError::TopBidderAccountMismatch.into());
+        }
+    } else {
+        return Err(AuctionContractError::AuctionIsInProgress.into());
+    }
+
+    let auction_root_state = AuctionRootState::read(auction_root_state_account)?;
+    match auction_root_state.token_config {
+        TokenConfig::Nft(ref nft_data) => {
+            let metadata_program = next_account_info(account_info_iter)?;
+            // nft child accounts
+            let child_edition_account = next_account_info(account_info_iter)?;
+            let child_edition_marker_account = next_account_info(account_info_iter)?;
+            let child_metadata_account = next_account_info(account_info_iter)?;
+            let child_mint_account = next_account_info(account_info_iter)?;
+            let child_holding_account = next_account_info(account_info_iter)?;
+            // master accounts
+            let master_edition_account = next_account_info(account_info_iter)?;
+            let master_metadata_account = next_account_info(account_info_iter)?;
+            let master_mint_account = next_account_info(account_info_iter)?;
+            let master_holding_account = next_account_info(account_info_iter)?;
+
+            // Check account ownership
+            // Accounts created in this instruction:
+            //   child_edition_account
+            //   child_metadata_account
+            //   child_mint_account
+            //   child_holding_account
+
+            if !child_edition_marker_account.data_is_empty()
+                && *child_edition_marker_account.owner != META_ID
+            {
+                return Err(AuctionContractError::InvalidAccountOwner.into());
+            }
+            if *master_edition_account.owner != META_ID {
+                return Err(AuctionContractError::InvalidAccountOwner.into());
+            }
+            assert_token_account_owner(master_holding_account, contract_pda.key)?;
+            assert_mint_authority(master_mint_account, master_edition_account.key)?;
+
+            // Check cross-program invocation addresses
+            assert_metaplex_program(metadata_program.key)?;
+
+            // Check pda addresses
+            // Not checking the following pdas since these are checked (and owned) by metaplex
+            // child_edition_account
+            // child_metadata_account
+            // child_edition_marker_account
+            // master_edition_account
+            // master_metadata_account
+            let child_mint_seeds = child_mint_seeds(&cycle_num_bytes, &auction_id);
+            let child_mint_pda =
+                SignerPda::new_checked(&child_mint_seeds, program_id, child_mint_account)?;
+
+            let child_holding_seeds = child_holding_seeds(&cycle_num_bytes, &auction_id);
+            let child_holding_pda =
+                SignerPda::new_checked(&child_holding_seeds, program_id, child_holding_account)?;
+
+            SignerPda::check_owner(
+                &master_mint_seeds(&auction_id),
+                program_id,
+                &TOKEN_ID,
+                master_mint_account,
+            )?;
+
+            SignerPda::check_owner(
+                &master_holding_seeds(&auction_id),
+                program_id,
+                &TOKEN_ID,
+                master_holding_account,
+            )?;
+
+            SignerPda::check_owner(
+                &metadata_seeds(master_mint_account.key),
+                &META_ID,
+                &META_ID,
+                master_metadata_account,
+            )?;
+
+            // check nft validity
+            if &nft_data.master_edition != master_edition_account.key {
+                return Err(AuctionContractError::MasterEditionMismatch.into());
+            }
+
+            if !child_metadata_account.data_is_empty() {
+                return Err(AuctionContractError::NftAlreadyExists.into());
+            }
+
+            // Mint child nft to highest bidder
+            // create child nft mint account
+            msg!("Mint account creation");
+            create_mint_account(
+                payer_account,
+                child_mint_account,
+                contract_pda,
+                child_mint_pda.signer_seeds(),
+                rent_program,
+                system_program,
+                token_program,
+                0,
+            )?;
+
+            msg!("Holding account creation");
+            // create child nft holding account
+            create_token_holding_account(
+                payer_account,
+                top_bidder_account,
+                child_holding_account,
+                child_mint_account,
+                child_holding_pda.signer_seeds(),
+                system_program,
+                token_program,
+                rent_program,
+            )?;
+
+            msg!("Minting nft");
+            let mint_ix = spl_token::instruction::mint_to(
+                token_program.key,
+                child_mint_account.key,
+                child_holding_account.key,
+                contract_pda.key,
+                &[contract_pda.key],
+                1,
+            )?;
+
+            invoke_signed(
+                &mint_ix,
+                &[
+                    contract_pda.to_owned(),
+                    token_program.to_owned(),
+                    child_holding_account.to_owned(),
+                    child_mint_account.to_owned(),
+                ],
+                &[&contract_signer_pda.signer_seeds()],
+            )?;
+
+            // change master metadata so that child can inherit it
+            msg!("Updating metadata account");
+            let mut new_master_metadata = try_from_slice_unchecked::<MetadataStateData>(
+                &master_metadata_account.data.borrow_mut()[METADATA_DATA_START_POS..],
+            )
+            .unwrap();
+
+            let edition_number_range =
+                find_edition_number_range_in_uri(&mut new_master_metadata.uri)?;
+            let current_edition_number =
+                u64::from_str(&new_master_metadata.uri[edition_number_range.clone()]).unwrap();
+
+            new_master_metadata
+                .uri
+                .replace_range(edition_number_range.clone(), &(cycle_number).to_string());
+
+            let change_master_metadata_ix = meta_instruction::update_metadata_accounts(
+                *metadata_program.key,
+                *master_metadata_account.key,
+                *contract_pda.key,
+                None,
+                Some(new_master_metadata.clone()),
+                None,
+            );
+
+            invoke_signed(
+                &change_master_metadata_ix,
+                &[master_metadata_account.clone(), contract_pda.clone()],
+                &[&contract_signer_pda.signer_seeds()],
+            )?;
+
+            // turn single child token into nft
+            msg!("Creating child nft");
+            let mint_child_ix = meta_instruction::mint_new_edition_from_master_edition_via_token(
+                *metadata_program.key,
+                *child_metadata_account.key,
+                *child_edition_account.key,
+                *master_edition_account.key,
+                *child_mint_account.key,
+                *contract_pda.key,
+                *payer_account.key,
+                *contract_pda.key,
+                *master_holding_account.key,
+                *contract_pda.key,
+                *master_metadata_account.key,
+                *master_mint_account.key,
+                cycle_number,
+            );
+
+            invoke_signed(
+                &mint_child_ix,
+                &[
+                    master_edition_account.clone(),
+                    master_holding_account.clone(),
+                    master_metadata_account.clone(),
+                    child_edition_account.clone(),
+                    child_edition_marker_account.clone(),
+                    child_holding_account.clone(),
+                    child_metadata_account.clone(),
+                    child_mint_account.clone(),
+                    payer_account.clone(),
+                    contract_pda.clone(),
+                    rent_program.clone(),
+                    system_program.clone(),
+                    token_program.clone(),
+                ],
+                &[&contract_signer_pda.signer_seeds()],
+            )?;
+
+            // Change metadata back to live edition number
+            new_master_metadata
+                .uri
+                .replace_range(edition_number_range, &(current_edition_number).to_string());
+
+            let change_master_metadata_ix = meta_instruction::update_metadata_accounts(
+                *metadata_program.key,
+                *master_metadata_account.key,
+                *contract_pda.key,
+                None,
+                Some(new_master_metadata),
+                None,
+            );
+
+            invoke_signed(
+                &change_master_metadata_ix,
+                &[master_metadata_account.clone(), contract_pda.clone()],
+                &[&contract_signer_pda.signer_seeds()],
+            )?;
+        }
+        TokenConfig::Token(ref token_data) => {
+            // Token mint account
+            let token_mint_account = next_account_info(account_info_iter)?;
+            // User's token holding account
+            let token_holding_account = next_account_info(account_info_iter)?;
+
+            // Check account ownership
+            // Accounts created in this instruction:
+            //   token_holding_account
+            assert_token_mint(&token_data.mint, token_mint_account)?;
+            assert_mint_authority(token_mint_account, contract_pda.key)?;
+            assert_owner(token_mint_account, &TOKEN_ID)?;
+
+            // SignerPda check is not required due to the previous checks
+            if token_mint_account.key != &token_data.mint {
+                return Err(AuctionContractError::InvalidSeeds.into());
+            }
+
+            let token_holding_seeds =
+                token_holding_seeds(token_mint_account.key, top_bidder_account.key);
+            let token_holding_pda =
+                SignerPda::new_checked(&token_holding_seeds, program_id, token_holding_account)?;
+
+            // create token holding account (if needed)
+            if token_holding_account.data_is_empty() {
+                create_token_holding_account(
+                    payer_account,
+                    top_bidder_account,
+                    token_holding_account,
+                    token_mint_account,
+                    token_holding_pda.signer_seeds(),
+                    system_program,
+                    token_program,
+                    rent_program,
+                )?;
+            }
+
+            // mint tokens to the highest bidder
+            let mint_ix = spl_token::instruction::mint_to(
+                token_program.key,
+                token_mint_account.key,
+                token_holding_account.key,
+                contract_pda.key,
+                &[contract_pda.key],
+                token_data.per_cycle_amount,
+            )?;
+
+            invoke_signed(
+                &mint_ix,
+                &[
+                    contract_pda.to_owned(),
+                    token_program.to_owned(),
+                    token_holding_account.to_owned(),
+                    token_mint_account.to_owned(),
+                ],
+                &[&contract_signer_pda.signer_seeds()],
+            )?;
+        }
+    }
+
+    auction_cycle_state.end_time = 0;
+    auction_cycle_state.write(auction_cycle_state_account)?;
+
+    Ok(())
+}
+
+pub fn find_edition_number_range_in_uri(
+    uri: &mut String,
+) -> Result<std::ops::Range<usize>, AuctionContractError> {
+    let uri_len = uri.len();
+    let mut last_pos = uri_len;
+    let mut dot_pos = uri_len;
+    let mut slash_pos = uri_len;
+
+    let str_bytes = uri.as_bytes();
+    for i in (0..uri_len).rev() {
+        if str_bytes[i] == 0 {
+            last_pos = i;
+        }
+
+        // ".".as_bytes() == [46]
+        if str_bytes[i] == 46 {
+            dot_pos = i;
+        }
+
+        // "/".as_bytes() == [47]
+        if str_bytes[i] == 47 {
+            slash_pos = i + 1;
+            break;
+        }
+    }
+
+    if last_pos == 0 || dot_pos == 0 || slash_pos == 0 || dot_pos < slash_pos {
+        return Err(AuctionContractError::MetadataManipulationError);
+    }
+
+    uri.truncate(last_pos);
+
+    Ok(slash_pos..dot_pos)
+}

--- a/contract/src/processor/claim_rewards.rs
+++ b/contract/src/processor/claim_rewards.rs
@@ -194,7 +194,7 @@ pub fn process_claim_rewards(
 
             // Mint child nft to highest bidder
             // create child nft mint account
-            msg!("Mint account creation");
+            //msg!("Mint account creation");
             create_mint_account(
                 payer_account,
                 child_mint_account,
@@ -206,7 +206,7 @@ pub fn process_claim_rewards(
                 0,
             )?;
 
-            msg!("Holding account creation");
+            //msg!("Holding account creation");
             // create child nft holding account
             create_token_holding_account(
                 payer_account,
@@ -219,7 +219,7 @@ pub fn process_claim_rewards(
                 rent_program,
             )?;
 
-            msg!("Minting nft");
+            //msg!("Minting nft");
             let mint_ix = spl_token::instruction::mint_to(
                 token_program.key,
                 child_mint_account.key,
@@ -241,7 +241,7 @@ pub fn process_claim_rewards(
             )?;
 
             // change master metadata so that child can inherit it
-            msg!("Updating metadata account");
+            //msg!("Updating metadata account");
             let mut new_master_metadata = try_from_slice_unchecked::<MetadataStateData>(
                 &master_metadata_account.data.borrow_mut()[METADATA_DATA_START_POS..],
             )
@@ -272,7 +272,7 @@ pub fn process_claim_rewards(
             )?;
 
             // turn single child token into nft
-            msg!("Creating child nft");
+            //msg!("Creating child nft");
             let mint_child_ix = meta_instruction::mint_new_edition_from_master_edition_via_token(
                 *metadata_program.key,
                 *child_metadata_account.key,

--- a/contract/src/processor/close_auction_cycle.rs
+++ b/contract/src/processor/close_auction_cycle.rs
@@ -312,6 +312,10 @@ pub fn close_auction_cycle(
     }
 
     auction_root_state.status.current_idle_cycle_streak = 0;
+    auction_root_state.unclaimed_rewards = auction_root_state
+        .unclaimed_rewards
+        .checked_add(1)
+        .ok_or(AuctionContractError::ArithmeticError)?;
     auction_root_state.write(auction_root_state_account)?;
 
     Ok(())
@@ -429,7 +433,8 @@ pub fn increment_uri(uri: &mut String, is_last_cycle: bool) -> Result<(), Auctio
         return Err(AuctionContractError::MetadataManipulationError);
     }
 
-    let integer = u64::from_str(&uri[slash_pos..dot_pos]).unwrap();
+    let integer = u64::from_str(&uri[slash_pos..dot_pos])
+        .map_err(|_| AuctionContractError::MetadataManipulationError)?;
     uri.truncate(last_pos);
     if is_last_cycle {
         uri.replace_range(slash_pos..dot_pos, &0.to_string());

--- a/contract/src/processor/delete_auction.rs
+++ b/contract/src/processor/delete_auction.rs
@@ -73,6 +73,11 @@ pub fn process_delete_auction(
         return Err(AuctionContractError::AuctionOwnerMismatch.into());
     }
 
+    // Check unclaimed rewards
+    if auction_root_state.unclaimed_rewards != 0 {
+        return Err(AuctionContractError::UnclaimedRewards.into());
+    }
+
     let removable_cycle_states_num = std::cmp::min(
         auction_root_state.status.current_auction_cycle,
         num_of_cycles_to_delete,

--- a/contract/src/processor/initialize_auction.rs
+++ b/contract/src/processor/initialize_auction.rs
@@ -417,6 +417,7 @@ pub fn initialize_auction(
         all_time_treasury: 0,
         available_funds: 0,
         start_time,
+        unclaimed_rewards: 0,
     };
     root_state.write(auction_root_state_account)?;
 

--- a/contract/src/processor/mod.rs
+++ b/contract/src/processor/mod.rs
@@ -1,6 +1,7 @@
 mod admin_withdraw;
 mod bid;
 mod claim_funds;
+mod claim_rewards;
 mod close_auction_cycle;
 mod delete_auction;
 mod filter_auction;
@@ -93,6 +94,9 @@ pub fn process(
         ),
         AuctionInstruction::ClaimFunds { id, amount } => {
             claim_funds::process_claim_funds(program_id, accounts, id, amount)
+        }
+        AuctionInstruction::ClaimRewards { id, cycle_number } => {
+            claim_rewards::process_claim_rewards(program_id, accounts, id, cycle_number)
         }
         AuctionInstruction::VerifyAuction { id } => {
             verify_auction::process_verify_auction(program_id, accounts, id)

--- a/contract/src/state.rs
+++ b/contract/src/state.rs
@@ -104,7 +104,7 @@ pub enum CreateTokenArgs {
     },
 }
 
-#[derive(Debug, Clone)]
+#[derive(BorshSchema, BorshDeserialize, BorshSerialize, Debug, Clone)]
 pub enum TokenType {
     Nft,
     Token,

--- a/contract/src/state.rs
+++ b/contract/src/state.rs
@@ -161,6 +161,8 @@ pub struct AuctionRootState {
     pub available_funds: u64,
     /// Start timestamp of the auction (in seconds)
     pub start_time: UnixTimestamp,
+    /// Number of unclaimed rewards
+    pub unclaimed_rewards: u16,
 }
 
 /// State respective to a given auction cycle.
@@ -340,6 +342,7 @@ mod test {
             all_time_treasury: 0,
             available_funds: 0,
             start_time: 0,
+            unclaimed_rewards: 0,
         };
 
         assert_eq!(

--- a/contract/tests/process_bid.rs
+++ b/contract/tests/process_bid.rs
@@ -7,40 +7,24 @@ use agsol_gold_contract::pda::*;
 use agsol_gold_contract::state::*;
 use agsol_gold_contract::AuctionContractError;
 use agsol_gold_contract::ID as CONTRACT_ID;
+use agsol_gold_contract::UNIVERSAL_BID_FLOOR;
 use agsol_testbench::{tokio, Testbench};
 use solana_program::pubkey::Pubkey;
 use solana_sdk::signer::Signer;
 
-async fn assert_auction_state(
-    testbench: &mut Testbench,
-    auction_id: [u8; 32],
-    expected_top_bidder: &Pubkey,
-    bid_amount: u64,
-) {
-    let (_auction_root_state_pubkey, auction_cycle_state_pubkey) =
-        get_state_pubkeys(testbench, auction_id).await.unwrap();
-    let (auction_bank_pubkey, _) =
-        Pubkey::find_program_address(&auction_bank_seeds(&auction_id), &CONTRACT_ID);
-
-    // Assert top bidder
-    if let Some(top_bid) = &get_top_bid(testbench, &auction_cycle_state_pubkey)
-        .await
-        .unwrap()
-    {
-        assert_eq!(&top_bid.bidder_pubkey, expected_top_bidder);
-        assert_eq!(top_bid.bid_amount, bid_amount);
-    }
-
-    // Assert fund holding account balance
-    let min_balance = testbench.rent.minimum_balance(0);
-    assert_eq!(
-        min_balance + bid_amount,
-        testbench
-            .get_account_lamports(&auction_bank_pubkey)
-            .await
-            .unwrap()
-    );
-}
+// This file includes the following tests:
+//
+// Valid use cases:
+//   - Bidding on nft auction
+//   - Bidding more than current top bid
+//   - Triggering encore period with a bid
+//   - (Test for bidding on token auctions in `process_tokens.rs`)
+//
+// Invalid use cases:
+//   - Bidding less than the minimum bid
+//   - Bidding less than current top bid
+//   - Bidding on auction after its current cycle has ended
+//   - (Test for bidding on ended auctions in `process_close_auction_cycle.rs`)
 
 #[tokio::test]
 async fn test_process_bid() {
@@ -83,12 +67,16 @@ async fn test_process_bid() {
 
     // Invalid use case
     // Test bid lower than minimum_bid
-    let lower_than_minimum_bid_error =
-        place_bid_transaction(&mut testbench, auction_id, &user_2.keypair, 10_000_000)
-            .await
-            .unwrap()
-            .err()
-            .unwrap();
+    let lower_than_minimum_bid_error = place_bid_transaction(
+        &mut testbench,
+        auction_id,
+        &user_2.keypair,
+        UNIVERSAL_BID_FLOOR - 1,
+    )
+    .await
+    .unwrap()
+    .err()
+    .unwrap();
 
     assert_eq!(
         lower_than_minimum_bid_error,
@@ -289,5 +277,36 @@ async fn test_encore_bid() {
     assert_eq!(
         end_time_after,
         block_time_before + auction_root_state.auction_config.encore_period
+    );
+}
+
+async fn assert_auction_state(
+    testbench: &mut Testbench,
+    auction_id: [u8; 32],
+    expected_top_bidder: &Pubkey,
+    bid_amount: u64,
+) {
+    let (_auction_root_state_pubkey, auction_cycle_state_pubkey) =
+        get_state_pubkeys(testbench, auction_id).await.unwrap();
+    let (auction_bank_pubkey, _) =
+        Pubkey::find_program_address(&auction_bank_seeds(&auction_id), &CONTRACT_ID);
+
+    // Assert top bidder
+    if let Some(top_bid) = &get_top_bid(testbench, &auction_cycle_state_pubkey)
+        .await
+        .unwrap()
+    {
+        assert_eq!(&top_bid.bidder_pubkey, expected_top_bidder);
+        assert_eq!(top_bid.bid_amount, bid_amount);
+    }
+
+    // Assert fund holding account balance
+    let min_balance = testbench.rent.minimum_balance(0);
+    assert_eq!(
+        min_balance + bid_amount,
+        testbench
+            .get_account_lamports(&auction_bank_pubkey)
+            .await
+            .unwrap()
     );
 }

--- a/contract/tests/process_claim_rewards.rs
+++ b/contract/tests/process_claim_rewards.rs
@@ -1,0 +1,380 @@
+#![cfg(feature = "test-bpf")]
+mod test_factory;
+
+use test_factory::*;
+
+use agsol_gold_contract::pda::*;
+use agsol_gold_contract::state::*;
+use agsol_gold_contract::AuctionContractError;
+
+use agsol_testbench::tokio;
+
+use solana_sdk::signer::Signer;
+
+const CLAIM_REWARDS_COST_NFT: u64 = 12_799_440;
+
+// This file includes the following tests:
+//
+// Valid use cases:
+//   - Claiming rewards from nft auctions
+//   - Claiming rewards from nft auctions chronologically and non-chronologically
+//   - (Test for claiming rewards from token auctions in `process_tokens.rs`)
+//
+// Invalid use cases:
+//   - Claiming rewards from ongoing cycle with and without placed bets
+//   - Claiming rewards using other than the top bidder account
+//   - Claiming already claimed rewards
+
+#[tokio::test]
+async fn test_process_claim_rewards_nft() {
+    let (mut testbench, auction_owner) = test_factory::testbench_setup().await.unwrap().unwrap();
+
+    let auction_id = [1; 32];
+    let auction_config = AuctionConfig {
+        cycle_period: 60,
+        encore_period: 1,
+        minimum_bid_amount: 50_000_000, // lamports
+        number_of_cycles: Some(1000),
+    };
+
+    let user_1 = TestUser::new(&mut testbench).await.unwrap().unwrap();
+    let payer = TestUser::new(&mut testbench)
+        .await
+        .unwrap()
+        .unwrap()
+        .keypair;
+
+    initialize_new_auction(
+        &mut testbench,
+        &auction_owner.keypair,
+        &auction_config,
+        auction_id,
+        TokenType::Nft,
+    )
+    .await
+    .unwrap()
+    .unwrap();
+
+    // Close first cycle
+    warp_to_cycle_end(&mut testbench, auction_id).await.unwrap();
+
+    let balance_change = close_cycle_transaction(
+        &mut testbench,
+        &payer,
+        auction_id,
+        &auction_owner.keypair.pubkey(),
+        TokenType::Nft,
+    )
+    .await
+    .unwrap()
+    .unwrap();
+
+    assert_eq!(-balance_change as u64, TRANSACTION_FEE);
+
+    // Invalid use case
+    // Try claiming rewards while no bids were taken
+    let claim_reward_from_ongoing_cycle_no_bids_error = claim_rewards_transaction(
+        &mut testbench,
+        &payer,
+        auction_id,
+        &user_1.keypair.pubkey(),
+        1,
+        TokenType::Nft,
+    )
+    .await
+    .unwrap()
+    .err()
+    .unwrap();
+
+    assert_eq!(
+        claim_reward_from_ongoing_cycle_no_bids_error,
+        AuctionContractError::AuctionIsInProgress
+    );
+
+    // Test some bids were taken
+    // Place bid
+    let bid_amount = 50_000_000;
+    place_bid_transaction(&mut testbench, auction_id, &user_1.keypair, bid_amount)
+        .await
+        .unwrap()
+        .unwrap();
+
+    // Invalid use case
+    // Try claiming rewards from ongoing cycle
+    let claim_reward_from_ongoing_cycle_error = claim_rewards_transaction(
+        &mut testbench,
+        &payer,
+        auction_id,
+        &user_1.keypair.pubkey(),
+        1,
+        TokenType::Nft,
+    )
+    .await
+    .unwrap()
+    .err()
+    .unwrap();
+
+    assert_eq!(
+        claim_reward_from_ongoing_cycle_error,
+        AuctionContractError::AuctionIsInProgress
+    );
+
+    // Close first cycle with bid this time
+    warp_to_cycle_end(&mut testbench, auction_id).await.unwrap();
+
+    close_cycle_transaction(
+        &mut testbench,
+        &payer,
+        auction_id,
+        &auction_owner.keypair.pubkey(),
+        TokenType::Nft,
+    )
+    .await
+    .unwrap()
+    .unwrap();
+
+    // Invalid use case
+    // Try claiming rewards to invalid top bidder account
+    let claim_reward_invalid_top_bidder_error = claim_rewards_transaction(
+        &mut testbench,
+        &payer,
+        auction_id,
+        &payer.pubkey(),
+        1,
+        TokenType::Nft,
+    )
+    .await
+    .unwrap()
+    .err()
+    .unwrap();
+
+    assert_eq!(
+        claim_reward_invalid_top_bidder_error,
+        AuctionContractError::TopBidderAccountMismatch
+    );
+
+    // Claim rewards
+    let balance_change = claim_rewards_transaction(
+        &mut testbench,
+        &payer,
+        auction_id,
+        &user_1.keypair.pubkey(),
+        1,
+        TokenType::Nft,
+    )
+    .await
+    .unwrap()
+    .unwrap();
+
+    assert_eq!(
+        -balance_change as u64,
+        CLAIM_REWARDS_COST_NFT + TRANSACTION_FEE
+    );
+
+    // Check if asset holding is created and asset is minted
+    let child_edition = EditionPda::new(EditionType::Child(1), &auction_id);
+    let user_1_nft_account = testbench
+        .get_token_account(&child_edition.holding)
+        .await
+        .unwrap();
+    let child_mint_account = testbench
+        .get_mint_account(&child_edition.mint)
+        .await
+        .unwrap();
+    assert_eq!(user_1_nft_account.mint, child_edition.mint);
+    assert_eq!(user_1_nft_account.owner, user_1.keypair.pubkey());
+    assert_eq!(user_1_nft_account.amount, 1);
+    assert_eq!(child_mint_account.supply, 1);
+
+    assert_metadata_uri(&mut testbench, &child_edition, "1.json").await;
+
+    // Invalid use case
+    // Trying to claim rewards again
+    let repeated_claim_reward_error = claim_rewards_transaction(
+        &mut testbench,
+        &payer,
+        auction_id,
+        &user_1.keypair.pubkey(),
+        1,
+        TokenType::Nft,
+    )
+    .await
+    .unwrap()
+    .err()
+    .unwrap();
+
+    assert_eq!(
+        repeated_claim_reward_error,
+        AuctionContractError::RewardAlreadyClaimed
+    );
+
+    // Check master metadata is correct after claim
+    let master_edition = EditionPda::new(EditionType::Master, &auction_id);
+    assert_metadata_uri(&mut testbench, &master_edition, "2.json").await;
+}
+
+#[tokio::test]
+async fn test_process_claim_rewards_nft_non_chronological() {
+    let (mut testbench, auction_owner) = test_factory::testbench_setup().await.unwrap().unwrap();
+
+    let auction_id = [1; 32];
+    let auction_config = AuctionConfig {
+        cycle_period: 60,
+        encore_period: 1,
+        minimum_bid_amount: 50_000_000, // lamports
+        number_of_cycles: Some(1000),
+    };
+
+    let user_1 = TestUser::new(&mut testbench).await.unwrap().unwrap();
+    let user_2 = TestUser::new(&mut testbench).await.unwrap().unwrap();
+    let payer = TestUser::new(&mut testbench)
+        .await
+        .unwrap()
+        .unwrap()
+        .keypair;
+
+    initialize_new_auction(
+        &mut testbench,
+        &auction_owner.keypair,
+        &auction_config,
+        auction_id,
+        TokenType::Nft,
+    )
+    .await
+    .unwrap()
+    .unwrap();
+
+    // Place bid on first cycle
+    let bid_amount = 50_000_000;
+    place_bid_transaction(&mut testbench, auction_id, &user_1.keypair, bid_amount)
+        .await
+        .unwrap()
+        .unwrap();
+
+    // Close first cycle
+    warp_to_cycle_end(&mut testbench, auction_id).await.unwrap();
+
+    close_cycle_transaction(
+        &mut testbench,
+        &payer,
+        auction_id,
+        &auction_owner.keypair.pubkey(),
+        TokenType::Nft,
+    )
+    .await
+    .unwrap()
+    .unwrap();
+
+    // Place bid on second cycle
+    let bid_amount = 50_000_000;
+    place_bid_transaction(&mut testbench, auction_id, &user_2.keypair, bid_amount)
+        .await
+        .unwrap()
+        .unwrap();
+
+    // Close second cycle
+    warp_to_cycle_end(&mut testbench, auction_id).await.unwrap();
+
+    close_cycle_transaction(
+        &mut testbench,
+        &payer,
+        auction_id,
+        &auction_owner.keypair.pubkey(),
+        TokenType::Nft,
+    )
+    .await
+    .unwrap()
+    .unwrap();
+
+    // Check that no child nfts have been claimed yet
+    let first_child_edition = EditionPda::new(EditionType::Child(1), &auction_id);
+    assert!(
+        !is_existing_account(&mut testbench, &first_child_edition.mint)
+            .await
+            .unwrap()
+    );
+
+    let second_child_edition = EditionPda::new(EditionType::Child(2), &auction_id);
+    assert!(
+        !is_existing_account(&mut testbench, &second_child_edition.mint)
+            .await
+            .unwrap()
+    );
+
+    // Claim rewards from second cycle
+    claim_rewards_transaction(
+        &mut testbench,
+        &payer,
+        auction_id,
+        &user_2.keypair.pubkey(),
+        2,
+        TokenType::Nft,
+    )
+    .await
+    .unwrap()
+    .unwrap();
+
+    // Check if asset holding is created and asset is minted
+    let user_2_nft_account = testbench
+        .get_token_account(&second_child_edition.holding)
+        .await
+        .unwrap();
+    let child_mint_account = testbench
+        .get_mint_account(&second_child_edition.mint)
+        .await
+        .unwrap();
+    assert_eq!(user_2_nft_account.mint, second_child_edition.mint);
+    assert_eq!(user_2_nft_account.owner, user_2.keypair.pubkey());
+    assert_eq!(user_2_nft_account.amount, 1);
+    assert_eq!(child_mint_account.supply, 1);
+
+    // Check that first child nft is still not created
+    assert!(
+        !is_existing_account(&mut testbench, &first_child_edition.mint)
+            .await
+            .unwrap()
+    );
+
+    // Check child metadata is correct
+    let child_edition = EditionPda::new(EditionType::Child(2), &auction_id);
+    assert_metadata_uri(&mut testbench, &child_edition, "2.json").await;
+
+    // Check master metadata is correct after claim
+    let master_edition = EditionPda::new(EditionType::Master, &auction_id);
+    assert_metadata_uri(&mut testbench, &master_edition, "3.json").await;
+
+    // Claim rewards from second cycle
+    claim_rewards_transaction(
+        &mut testbench,
+        &payer,
+        auction_id,
+        &user_1.keypair.pubkey(),
+        1,
+        TokenType::Nft,
+    )
+    .await
+    .unwrap()
+    .unwrap();
+
+    // Check if asset holding is created and asset is minted
+    let user_1_nft_account = testbench
+        .get_token_account(&first_child_edition.holding)
+        .await
+        .unwrap();
+    let child_mint_account = testbench
+        .get_mint_account(&first_child_edition.mint)
+        .await
+        .unwrap();
+    assert_eq!(user_1_nft_account.mint, first_child_edition.mint);
+    assert_eq!(user_1_nft_account.owner, user_1.keypair.pubkey());
+    assert_eq!(user_1_nft_account.amount, 1);
+    assert_eq!(child_mint_account.supply, 1);
+
+    // Check child metadata is correct
+    let child_edition = EditionPda::new(EditionType::Child(1), &auction_id);
+    assert_metadata_uri(&mut testbench, &child_edition, "1.json").await;
+
+    // Check master metadata is correct after claim
+    let master_edition = EditionPda::new(EditionType::Master, &auction_id);
+    assert_metadata_uri(&mut testbench, &master_edition, "3.json").await;
+}

--- a/contract/tests/process_initialize_auction.rs
+++ b/contract/tests/process_initialize_auction.rs
@@ -15,7 +15,7 @@ use agsol_token_metadata::ID as META_ID;
 use solana_program::program_option::COption;
 use solana_program::pubkey::Pubkey;
 
-const AUCTION_CREATION_COST: u64 = 24_116_400 + TRANSACTION_FEE;
+const AUCTION_CREATION_COST: u64 = 24_102_480 + TRANSACTION_FEE;
 
 // This file includes the following tests:
 //

--- a/contract/tests/process_initialize_auction.rs
+++ b/contract/tests/process_initialize_auction.rs
@@ -15,7 +15,7 @@ use agsol_token_metadata::ID as META_ID;
 use solana_program::program_option::COption;
 use solana_program::pubkey::Pubkey;
 
-const AUCTION_CREATION_COST: u64 = 24_102_480 + TRANSACTION_FEE;
+const AUCTION_CREATION_COST: u64 = 24_116_400 + TRANSACTION_FEE;
 
 // This file includes the following tests:
 //
@@ -272,6 +272,7 @@ async fn test_process_initialize_auction() {
     assert_eq!(auction_root_state.status.current_auction_cycle, 1);
     assert_eq!(auction_root_state.status.current_idle_cycle_streak, 0);
     assert!(auction_cycle_state.bid_history.get_last_element().is_none());
+    assert_eq!(auction_root_state.unclaimed_rewards, 0);
 
     let (auction_pool_pubkey, _) =
         Pubkey::find_program_address(&auction_pool_seeds(), &CONTRACT_ID);

--- a/contract/tests/process_initialize_auction.rs
+++ b/contract/tests/process_initialize_auction.rs
@@ -17,6 +17,23 @@ use solana_program::pubkey::Pubkey;
 
 const AUCTION_CREATION_COST: u64 = 24_102_480 + TRANSACTION_FEE;
 
+// This file includes the following tests:
+//
+// Valid use cases:
+//   - Creating nft auction
+//   - (Test for creating token auction in `process_tokens.rs`)
+//
+// Invalid use cases:
+//   - Creating auction with non-ascii charactes in its id
+//   - Creating auction with minimum_bid_amount lower than UNIVERSAL_BID_FLOOR
+//   - Creating auction with too short cycle period
+//   - Creating auction with too long cycle period
+//   - Creating auction with negative encore period
+//   - Creating auction with too long encore period
+//   - Create auction with an id already taken by the same user
+//   - Create auction with an id already taken by another user
+//   - (Test for trying to initialize an auction with a full pool in `process_reallocate_pool.rs`)
+
 #[tokio::test]
 async fn test_process_initialize_auction() {
     let (mut testbench, auction_owner) = test_factory::testbench_setup().await.unwrap().unwrap();
@@ -31,7 +48,8 @@ async fn test_process_initialize_auction() {
         number_of_cycles: Some(10),
     };
 
-    // invalid auction id (not ascii)
+    // Invalid use case
+    // Creating auction with non-ascii characters in its id
     let invalid_auction_id_error = initialize_new_auction(
         &mut testbench,
         &auction_owner.keypair,
@@ -71,7 +89,8 @@ async fn test_process_initialize_auction() {
         AuctionContractError::InvalidMinimumBidAmount
     );
 
-    // cycle period too small
+    // Invalid use case
+    // Creating auction with too short cycle period
     auction_config.cycle_period = 30;
     auction_config.minimum_bid_amount = 50_000_000;
 
@@ -92,7 +111,8 @@ async fn test_process_initialize_auction() {
         AuctionContractError::InvalidCyclePeriod
     );
 
-    // cycle period too large
+    // Invalid use case
+    // Creating auction with too long cycle period
     auction_config.cycle_period = 50_000_000;
     let invalid_cycle_period_error = initialize_new_auction(
         &mut testbench,
@@ -113,6 +133,49 @@ async fn test_process_initialize_auction() {
 
     auction_config.cycle_period = 60;
 
+    // Invalid use case
+    // Creating auction with negative encore period
+    auction_config.encore_period = -1;
+    let negative_encore_period_error = initialize_new_auction(
+        &mut testbench,
+        &auction_owner.keypair,
+        &auction_config,
+        auction_id,
+        TokenType::Nft,
+    )
+    .await
+    .unwrap()
+    .err()
+    .unwrap();
+
+    assert_eq!(
+        negative_encore_period_error,
+        AuctionContractError::InvalidEncorePeriod
+    );
+
+    // Invalid use case
+    // Creating auction with too long encore period
+    auction_config.encore_period = auction_config.cycle_period / 2 + 1;
+    let negative_encore_period_error = initialize_new_auction(
+        &mut testbench,
+        &auction_owner.keypair,
+        &auction_config,
+        auction_id,
+        TokenType::Nft,
+    )
+    .await
+    .unwrap()
+    .err()
+    .unwrap();
+
+    assert_eq!(
+        negative_encore_period_error,
+        AuctionContractError::InvalidEncorePeriod
+    );
+
+    auction_config.encore_period = 0;
+
+    // Create a valid auction
     let balance_change = initialize_new_auction(
         &mut testbench,
         &auction_owner.keypair,
@@ -220,7 +283,7 @@ async fn test_process_initialize_auction() {
     assert_eq!(auction_pool.pool[0], [123_u8; 32]);
 
     // Invalid use case
-    // Create auction with the same id
+    // Create auction with an id already taken by the same user
     let reinitialize_auction_error = initialize_new_auction(
         &mut testbench,
         &auction_owner.keypair,
@@ -237,8 +300,9 @@ async fn test_process_initialize_auction() {
         AuctionContractError::AuctionIdNotUnique
     );
 
+    // Invalid use case
+    // Create auction with an id already taken by another user
     let other_user = TestUser::new(&mut testbench).await.unwrap().unwrap();
-
     let initialize_auction_with_same_id_error = initialize_new_auction(
         &mut testbench,
         &other_user.keypair,

--- a/contract/tests/process_modify_auction.rs
+++ b/contract/tests/process_modify_auction.rs
@@ -9,6 +9,17 @@ use agsol_gold_contract::ID as CONTRACT_ID;
 use agsol_testbench::tokio;
 use solana_program::pubkey::Pubkey;
 
+// This file includes the following tests:
+//
+// Valid use cases:
+//   - Modifying auction description
+//   - Modifying auction socials
+//   - Modifying auction encore period within valid bounds
+//
+// Invalid use cases:
+//   - Modifying auction without owner signature
+//   - Modifying auction encore period to invalid value
+
 #[tokio::test]
 async fn test_process_modify_auction() {
     let (mut testbench, auction_owner) = test_factory::testbench_setup().await.unwrap().unwrap();
@@ -135,7 +146,7 @@ async fn test_process_modify_auction() {
     // modify encore period
 
     // Invalid use case
-    // encore period exceeds cycle_period/2
+    // Trying to modify encore period over cycle_period/2
     let modify_data = ModifyAuctionData {
         new_description: None,
         new_socials: None,

--- a/contract/tests/process_reallocate_pool.rs
+++ b/contract/tests/process_reallocate_pool.rs
@@ -11,6 +11,19 @@ use agsol_testbench::tokio;
 use solana_program::pubkey::Pubkey;
 use solana_sdk::signature::Signer;
 
+// This file includes the following tests:
+//
+// Valid use cases:
+//   - Reallocating primary pool with admin signature
+//   - Reallocating secondary pool with admin signature
+//
+// Invalid use cases:
+//   - Trying to initialize an auction with a full pool
+//   - Trying to deallocate/reallocate without admin signature
+//   - Trying to shrink the pool
+//   - Trying to reallocate to a too large size
+//   - Reallocating pool with invalid seeds
+
 #[tokio::test]
 async fn test_process_reallocate_pool() {
     let (mut testbench, auction_owner) = test_factory::testbench_setup().await.unwrap().unwrap();
@@ -66,7 +79,9 @@ async fn test_process_reallocate_pool() {
     assert_eq!(auction_pool.pool.len(), INITIAL_AUCTION_POOL_LEN as usize);
 
     auction_id = [INITIAL_AUCTION_POOL_LEN as u8; 32];
-    // try to initialize an auction with a full pool
+
+    // Invalid use case
+    // Trying to initialize an auction with a full pool
     let initialize_auction_with_full_pool_error = initialize_new_auction(
         &mut testbench,
         &auction_owner.keypair,
@@ -148,7 +163,8 @@ async fn test_process_reallocate_pool() {
     assert_eq!(auction_pool.max_len, new_max_len);
     assert_eq!(auction_pool.pool, vec![[0; 32], [1; 32], [2; 32], [3; 32]]);
 
-    // try to deallocate/reallocate without admin authority
+    // Invalid use case
+    // Trying to deallocate/reallocate without admin signature
     let reallocate_instruction =
         reallocate_pool(&auction_owner.keypair.pubkey(), 0, auction_pool_seeds);
     let error = testbench
@@ -162,8 +178,10 @@ async fn test_process_reallocate_pool() {
         AuctionContractError::ContractAdminMismatch
     );
 
-    // try to shrink the pool, sending these together is fine now,
-    // because the size check is before the system program is called
+    // Invalid use case
+    // Trying to shrink the pool
+    // Sending these together is fine now, because the size check
+    // is performed before the system program is called
     let reallocate_instruction = reallocate_pool(&payer.pubkey(), 1, auction_pool_seeds);
     let error = testbench
         .process_transaction(&[reallocate_instruction], &payer, None)
@@ -176,7 +194,8 @@ async fn test_process_reallocate_pool() {
         AuctionContractError::ShrinkingPoolIsNotAllowed
     );
 
-    // try to reallocate to a too large size
+    // Invalid use case
+    // Trying to reallocate to a too large size
     let reallocate_instruction = reallocate_pool(&payer.pubkey(), 350_000, auction_pool_seeds);
     let result = testbench
         .process_transaction(&[reallocate_instruction], &payer, None)
@@ -201,7 +220,8 @@ async fn test_process_reallocate_pool() {
 
     assert_eq!(secondary_pool.max_len, new_secondary_len);
 
-    // reallocate with invalid seeds
+    // Invalid use case
+    // Reallocating pool with invalid seeds
     let reallocate_instruction =
         reallocate_pool(&payer.pubkey(), new_secondary_len, contract_bank_seeds);
     let result = testbench

--- a/contract/tests/process_tokens.rs
+++ b/contract/tests/process_tokens.rs
@@ -13,6 +13,22 @@ use agsol_gold_contract::AuctionContractError;
 use agsol_gold_contract::ID as CONTRACT_ID;
 use agsol_testbench::{tokio, TestbenchError};
 
+// This file includes the following tests:
+//
+// Valid use cases:
+//   - Creating token auction
+//   - Creating token auction using existing mint
+//   - Bidding on token auction
+//   - Closing token auction cycle with and without placed bids
+//   - Claiming rewards from token auction non-chronologically
+//   - Claiming rewards from token auction initialized with existing mint
+//
+// Invalid use cases:
+//   - Creating token auction with 0 per_cycle_amount
+
+const CLOSE_CYCLE_COST: u64 = 3_758_400;
+const CLAIM_REWARDS_COST_TOKEN: u64 = 2_039_280;
+
 #[tokio::test]
 async fn test_process_tokens() {
     let (mut testbench, auction_owner) = test_factory::testbench_setup().await.unwrap().unwrap();
@@ -31,7 +47,8 @@ async fn test_process_tokens() {
         number_of_cycles: Some(1000),
     };
 
-    //  initialize auction with 0 per cycle token amount
+    // Invalid use case
+    // Initialize auction with 0 per cycle token amount
     let create_token_args = CreateTokenArgs::Token {
         decimals: 0,
         per_cycle_amount: 0,
@@ -54,7 +71,7 @@ async fn test_process_tokens() {
         AuctionContractError::InvalidPerCycleAmount,
     );
 
-    // initialize properly
+    // Initialize properly
     initialize_new_auction(
         &mut testbench,
         &auction_owner.keypair,
@@ -76,14 +93,11 @@ async fn test_process_tokens() {
         .await
         .unwrap();
 
+    // Check created mint
     assert_eq!(token_mint.mint_authority, COption::Some(contract_pda));
-
     assert_eq!(token_mint.supply, 0);
-
     assert_eq!(token_mint.decimals, 1);
-
     assert!(token_mint.is_initialized);
-
     assert_eq!(token_mint.freeze_authority, COption::None);
 
     // Test no bids were taken
@@ -100,6 +114,7 @@ async fn test_process_tokens() {
     .unwrap()
     .unwrap();
 
+    // Check that no tokens were minted
     let token_mint = testbench
         .get_mint_account(&token_mint_pubkey)
         .await
@@ -142,33 +157,33 @@ async fn test_process_tokens() {
     .unwrap()
     .unwrap();
 
+    // Check that closing the cycle did not mint any tokens
     let token_mint = testbench
         .get_mint_account(&token_mint_pubkey)
         .await
         .unwrap();
-    assert_eq!(token_mint.supply, 100);
+    assert_eq!(token_mint.supply, 0);
 
-    let (token_holding_pubkey, _) = Pubkey::find_program_address(
-        &token_holding_seeds(&token_mint_pubkey, &user_1.keypair.pubkey()),
-        &CONTRACT_ID,
+    assert_eq!(
+        testbench
+            .get_token_account(&token_holding_pubkey)
+            .await
+            .err()
+            .unwrap(),
+        TestbenchError::AccountNotFound
     );
-    let token_holding = testbench
-        .get_token_account(&token_holding_pubkey)
-        .await
-        .unwrap();
-    assert_eq!(token_holding.amount, 100);
-    assert_eq!(token_holding.owner, user_1.keypair.pubkey());
 }
 
 #[tokio::test]
 async fn test_process_tokens_existing_mint() {
     let (mut testbench, auction_owner) = test_factory::testbench_setup().await.unwrap().unwrap();
 
-    let auction_cycle_payer = TestUser::new(&mut testbench)
+    let payer = TestUser::new(&mut testbench)
         .await
         .unwrap()
         .unwrap()
         .keypair;
+    let user = TestUser::new(&mut testbench).await.unwrap().unwrap();
 
     let auction_id = [1; 32];
     let auction_config = AuctionConfig {
@@ -185,9 +200,10 @@ async fn test_process_tokens_existing_mint() {
         .unwrap();
 
     //  initialize auction with existing mint
+    let per_cycle_amount = 100;
     let create_token_args = CreateTokenArgs::Token {
         decimals: 0,
-        per_cycle_amount: 100,
+        per_cycle_amount,
         existing_mint: Some(token_mint_pubkey),
     };
     initialize_new_auction_custom(
@@ -209,11 +225,9 @@ async fn test_process_tokens_existing_mint() {
     let contract_pda_pubkey = Pubkey::find_program_address(&contract_pda_seeds(), &CONTRACT_ID).0;
     assert_eq!(mint_info.mint_authority.unwrap(), contract_pda_pubkey);
 
-    // Test token minting
-    let user_1 = TestUser::new(&mut testbench).await.unwrap().unwrap();
-
+    // Placing bid
     let bid_amount = 50_000_000;
-    place_bid_transaction(&mut testbench, auction_id, &user_1.keypair, bid_amount)
+    place_bid_transaction(&mut testbench, auction_id, &user.keypair, bid_amount)
         .await
         .unwrap()
         .unwrap();
@@ -223,7 +237,7 @@ async fn test_process_tokens_existing_mint() {
 
     close_cycle_transaction(
         &mut testbench,
-        &auction_cycle_payer,
+        &payer,
         auction_id,
         &auction_owner.keypair.pubkey(),
         TokenType::Token,
@@ -232,20 +246,208 @@ async fn test_process_tokens_existing_mint() {
     .unwrap()
     .unwrap();
 
+    // Check that no tokens were minted after cycle closing
     let token_mint = testbench
         .get_mint_account(&token_mint_pubkey)
         .await
         .unwrap();
-    assert_eq!(token_mint.supply, 100);
+    assert_eq!(token_mint.supply, 0);
 
     let (token_holding_pubkey, _) = Pubkey::find_program_address(
-        &token_holding_seeds(&token_mint_pubkey, &user_1.keypair.pubkey()),
+        &token_holding_seeds(&token_mint_pubkey, &user.keypair.pubkey()),
         &CONTRACT_ID,
     );
-    let token_holding = testbench
+    assert!(!is_existing_account(&mut testbench, &token_holding_pubkey)
+        .await
+        .unwrap());
+
+    // Claiming token rewards
+    let balance_change = claim_rewards_transaction(
+        &mut testbench,
+        &payer,
+        auction_id,
+        &user.keypair.pubkey(),
+        1,
+        TokenType::Token,
+    )
+    .await
+    .unwrap()
+    .unwrap();
+
+    assert_eq!(
+        -balance_change as u64,
+        CLAIM_REWARDS_COST_TOKEN + TRANSACTION_FEE
+    );
+
+    // Check that tokens were minted upon claim
+    let token_mint = testbench
+        .get_mint_account(&token_mint_pubkey)
+        .await
+        .unwrap();
+    assert_eq!(token_mint.supply, per_cycle_amount);
+
+    assert!(is_existing_account(&mut testbench, &token_holding_pubkey)
+        .await
+        .unwrap());
+
+    let user_token_account = testbench
         .get_token_account(&token_holding_pubkey)
         .await
         .unwrap();
-    assert_eq!(token_holding.amount, 100);
-    assert_eq!(token_holding.owner, user_1.keypair.pubkey());
+    assert_eq!(user_token_account.amount, per_cycle_amount);
+    assert_eq!(user_token_account.owner, user.keypair.pubkey());
+}
+
+#[tokio::test]
+async fn test_process_claim_rewards_token_non_chronological() {
+    let (mut testbench, auction_owner) = test_factory::testbench_setup().await.unwrap().unwrap();
+
+    let auction_id = [1; 32];
+    let auction_config = AuctionConfig {
+        cycle_period: 60,
+        encore_period: 1,
+        minimum_bid_amount: 50_000_000, // lamports
+        number_of_cycles: Some(1000),
+    };
+
+    let (auction_root_state_pubkey, _) =
+        Pubkey::find_program_address(&auction_root_state_seeds(&auction_id), &CONTRACT_ID);
+
+    let user_1 = TestUser::new(&mut testbench).await.unwrap().unwrap();
+    let user_2 = TestUser::new(&mut testbench).await.unwrap().unwrap();
+    let payer = TestUser::new(&mut testbench)
+        .await
+        .unwrap()
+        .unwrap()
+        .keypair;
+
+    initialize_new_auction(
+        &mut testbench,
+        &auction_owner.keypair,
+        &auction_config,
+        auction_id,
+        TokenType::Token,
+    )
+    .await
+    .unwrap()
+    .unwrap();
+
+    // Place bid on first cycle
+    let bid_amount = 50_000_000;
+    place_bid_transaction(&mut testbench, auction_id, &user_1.keypair, bid_amount)
+        .await
+        .unwrap()
+        .unwrap();
+
+    // Close first cycle
+    warp_to_cycle_end(&mut testbench, auction_id).await.unwrap();
+
+    let balance_change = close_cycle_transaction(
+        &mut testbench,
+        &payer,
+        auction_id,
+        &auction_owner.keypair.pubkey(),
+        TokenType::Token,
+    )
+    .await
+    .unwrap()
+    .unwrap();
+
+    assert_eq!(-balance_change as u64, CLOSE_CYCLE_COST + TRANSACTION_FEE,);
+
+    // Place bid on second cycle
+    let bid_amount = 50_000_000;
+    place_bid_transaction(&mut testbench, auction_id, &user_2.keypair, bid_amount)
+        .await
+        .unwrap()
+        .unwrap();
+
+    // Close second cycle
+    warp_to_cycle_end(&mut testbench, auction_id).await.unwrap();
+
+    let balance_change = close_cycle_transaction(
+        &mut testbench,
+        &payer,
+        auction_id,
+        &auction_owner.keypair.pubkey(),
+        TokenType::Token,
+    )
+    .await
+    .unwrap()
+    .unwrap();
+
+    assert_eq!(-balance_change as u64, CLOSE_CYCLE_COST + TRANSACTION_FEE,);
+
+    // Check that no tokens have been claimed yet
+    let token_data = get_token_data(&mut testbench, &auction_root_state_pubkey)
+        .await
+        .unwrap()
+        .unwrap();
+    let token_mint = testbench.get_mint_account(&token_data.mint).await.unwrap();
+    assert_eq!(token_mint.supply, 0);
+
+    // Claim rewards from first cycle
+    let balance_change = claim_rewards_transaction(
+        &mut testbench,
+        &payer,
+        auction_id,
+        &user_1.keypair.pubkey(),
+        1,
+        TokenType::Token,
+    )
+    .await
+    .unwrap()
+    .unwrap();
+
+    assert_eq!(
+        -balance_change as u64,
+        CLAIM_REWARDS_COST_TOKEN + TRANSACTION_FEE
+    );
+
+    // Check if asset holding is created and asset is minted
+    let (user_1_holding_pubkey, _) = Pubkey::find_program_address(
+        &token_holding_seeds(&token_data.mint, &user_1.keypair.pubkey()),
+        &CONTRACT_ID,
+    );
+    assert!(is_existing_account(&mut testbench, &user_1_holding_pubkey)
+        .await
+        .unwrap());
+
+    let token_mint = testbench.get_mint_account(&token_data.mint).await.unwrap();
+    assert_eq!(token_mint.supply, token_data.per_cycle_amount,);
+
+    // Check that second holding account is not created
+    let (user_2_holding_pubkey, _) = Pubkey::find_program_address(
+        &token_holding_seeds(&token_data.mint, &user_2.keypair.pubkey()),
+        &CONTRACT_ID,
+    );
+    assert!(!is_existing_account(&mut testbench, &user_2_holding_pubkey)
+        .await
+        .unwrap());
+
+    // Claim rewards from second cycle
+    let balance_change = claim_rewards_transaction(
+        &mut testbench,
+        &payer,
+        auction_id,
+        &user_2.keypair.pubkey(),
+        2,
+        TokenType::Token,
+    )
+    .await
+    .unwrap()
+    .unwrap();
+
+    assert_eq!(
+        -balance_change as u64,
+        CLAIM_REWARDS_COST_TOKEN + TRANSACTION_FEE
+    );
+
+    // Check if asset holding is created and asset is minted
+    assert!(is_existing_account(&mut testbench, &user_2_holding_pubkey)
+        .await
+        .unwrap());
+
+    let token_mint = testbench.get_mint_account(&token_data.mint).await.unwrap();
+    assert_eq!(token_mint.supply, 2 * token_data.per_cycle_amount,);
 }

--- a/contract/tests/process_verify_auction.rs
+++ b/contract/tests/process_verify_auction.rs
@@ -4,9 +4,19 @@ use test_factory::*;
 
 use agsol_gold_contract::pda::*;
 use agsol_gold_contract::state::*;
+use agsol_gold_contract::AuctionContractError;
 use agsol_gold_contract::ID as CONTRACT_ID;
 use agsol_testbench::tokio;
 use solana_program::pubkey::Pubkey;
+
+// This file includes the following tests:
+//
+// Valid use cases:
+//   - Verifying an auction with admin signature
+//   - Verifying an already verified auction
+//
+// Invalid use cases:
+//   - Verifying without contract admin signature
 
 #[tokio::test]
 async fn test_process_verify_auction() {
@@ -39,6 +49,20 @@ async fn test_process_verify_auction() {
         .await
         .unwrap();
     assert!(!auction_root_state.status.is_verified);
+
+    // Invalid use case
+    // Verifying without admin signature
+    let verify_without_admin_signature =
+        verify_auction_transaction(&mut testbench, auction_id, &auction_owner.keypair)
+            .await
+            .unwrap()
+            .err()
+            .unwrap();
+
+    assert_eq!(
+        verify_without_admin_signature,
+        AuctionContractError::ContractAdminMismatch
+    );
 
     // Verifying auction
     let payer = testbench.clone_payer();

--- a/contract/tests/test_factory.rs
+++ b/contract/tests/test_factory.rs
@@ -15,12 +15,14 @@ use solana_sdk::transaction::TransactionError;
 use agsol_gold_contract::instruction::factory::*;
 use agsol_gold_contract::pda::{
     auction_bank_seeds, auction_cycle_state_seeds, auction_root_state_seeds,
+    protocol_fee_state_seeds, EditionPda,
 };
 use agsol_gold_contract::state::{
     AuctionConfig, AuctionCycleState, AuctionDescription, AuctionRootState, BidData,
     CreateTokenArgs, ModifyAuctionData, NftData, ProtocolFeeState, TokenConfig, TokenData,
     TokenType,
 };
+use agsol_gold_contract::utils::unpuff_metadata;
 use agsol_gold_contract::AuctionContractError;
 use agsol_gold_contract::ID as CONTRACT_ID;
 use agsol_gold_contract::{DEFAULT_PROTOCOL_FEE, RECOMMENDED_CYCLE_STATES_DELETED_PER_CALL};
@@ -30,6 +32,7 @@ use agsol_testbench::solana_program_test::{self, processor};
 use agsol_testbench::{
     Testbench, TestbenchError, TestbenchProgram, TestbenchResult, TestbenchTransactionResult,
 };
+use agsol_token_metadata::state::Metadata;
 
 pub const TRANSACTION_FEE: u64 = 5000;
 pub const INITIAL_AUCTION_POOL_LEN: u32 = 3;
@@ -351,6 +354,19 @@ pub async fn modify_auction_transaction(
         .map(|transaction_result| transaction_result.map_err(to_auction_error))
 }
 
+pub async fn get_protocol_fee_multiplier(testbench: &mut Testbench) -> f64 {
+    let (protocol_fee_state_pubkey, _) =
+        Pubkey::find_program_address(&protocol_fee_state_seeds(), &CONTRACT_ID);
+
+    let fee_state = testbench
+        .get_and_deserialize_account_data::<ProtocolFeeState>(&protocol_fee_state_pubkey)
+        .await
+        .unwrap_or(ProtocolFeeState {
+            fee: DEFAULT_PROTOCOL_FEE,
+        });
+    fee_state.fee as f64 / 1_000.0
+}
+
 pub async fn claim_and_assert_split(
     testbench: &mut Testbench,
     auction_id: [u8; 32],
@@ -404,7 +420,7 @@ pub async fn claim_and_assert_split(
 
 pub async fn claim_funds_transaction(
     testbench: &mut Testbench,
-    caller_keypair: &Keypair,
+    payer_keypair: &Keypair,
     auction_id: [u8; 32],
     auction_owner_pubkey: &Pubkey,
     amount: u64,
@@ -413,7 +429,7 @@ pub async fn claim_funds_transaction(
         Pubkey::find_program_address(&auction_root_state_seeds(&auction_id), &CONTRACT_ID);
 
     let claim_funds_args = ClaimFundsArgs {
-        caller_pubkey: caller_keypair.pubkey(),
+        payer_pubkey: payer_keypair.pubkey(),
         auction_owner_pubkey: *auction_owner_pubkey,
         auction_id,
         cycle_number: get_current_cycle_number(testbench, &auction_root_state_pubkey).await?,
@@ -425,7 +441,7 @@ pub async fn claim_funds_transaction(
     let owner_balance_before = testbench.get_account_lamports(auction_owner_pubkey).await?;
 
     let testbench_result = testbench
-        .process_transaction(&[claim_funds_ix], caller_keypair, None)
+        .process_transaction(&[claim_funds_ix], payer_keypair, None)
         .await
         .map(|transaction_result| transaction_result.map_err(to_auction_error));
 
@@ -435,6 +451,57 @@ pub async fn claim_funds_transaction(
     testbench_result.map(|transaction_result| {
         transaction_result.map(|_signer_balance_change| owner_balance_change)
     })
+}
+
+pub async fn claim_rewards_transaction(
+    testbench: &mut Testbench,
+    payer_keypair: &Keypair,
+    auction_id: [u8; 32],
+    top_bidder_pubkey: &Pubkey,
+    cycle_number: u64,
+    token_type: TokenType,
+) -> AuctionTransactionResult {
+    let (auction_root_state_pubkey, _) =
+        Pubkey::find_program_address(&auction_root_state_seeds(&auction_id), &CONTRACT_ID);
+
+    let existing_token_mint = match token_type {
+        TokenType::Token => {
+            let token_data = get_token_data(testbench, &auction_root_state_pubkey)
+                .await?
+                .ok_or(TestbenchError::AccountNotFound)?;
+            Some(token_data.mint)
+        }
+        TokenType::Nft => None,
+    };
+
+    let claim_rewards_args = ClaimRewardsArgs {
+        payer_pubkey: payer_keypair.pubkey(),
+        top_bidder_pubkey: *top_bidder_pubkey,
+        auction_id,
+        cycle_number,
+        token_type,
+        existing_token_mint,
+    };
+
+    let claim_rewards_ix = claim_rewards(&claim_rewards_args);
+
+    testbench
+        .process_transaction(&[claim_rewards_ix], payer_keypair, None)
+        .await
+        .map(|transaction_result| transaction_result.map_err(to_auction_error))
+}
+
+pub async fn assert_metadata_uri(
+    testbench: &mut Testbench,
+    edition_pda: &EditionPda,
+    expected_uri_ending: &str,
+) {
+    let mut metadata = testbench
+        .get_and_deserialize_account_data::<Metadata>(&edition_pda.metadata)
+        .await
+        .unwrap();
+    unpuff_metadata(&mut metadata.data);
+    assert!(metadata.data.uri.ends_with(expected_uri_ending));
 }
 
 pub async fn place_bid_transaction(

--- a/contract/tests/test_factory.rs
+++ b/contract/tests/test_factory.rs
@@ -42,10 +42,10 @@ pub fn to_auction_error(program_err: TransactionError) -> AuctionContractError {
         TransactionError::InstructionError(_, InstructionError::Custom(code)) => {
             FromPrimitive::from_u32(code).unwrap()
         }
-        //_ => unimplemented!(),
         _ => {
             dbg!(program_err);
-            AuctionContractError::InvalidAccountOwner
+            // Return some error instead of panicking
+            AuctionContractError::ShrinkingPoolIsNotAllowed
             //unimplemented!();
         }
     }


### PR DESCRIPTION
## Description

Aims to resolve #65 .
Separated cycle closing and reward (nft or token) minting into different instructions. Closing a cycle no longer mints the reward automatically to the top bidder. 

The `CloseCycle` instruction performs the following now:

- Manages idle auctions (incrementing and moving auction between pools if needed)
- Increments the master metadata so it contains the uri of the currently auctioned nft
- Initializes the next cycle's state
- Manages auction closing when closing last cycle

The `ClaimRewards` instruction lets the users mint their reward for winning an auction cycle. When an auction cycle's reward is claimed the cycle's end time is set to 0 so that no rewards can be claimed twice. Everyone can call this instruction for any auction and any cycle, just like `CloseCycle`.

## State changes

Two of the 32 reserved extra bytes in `AuctionRootState` is used to track the number of unclaimed rewards in the auction. All rewards must be claimed from an auction before it can be deleted.