### PR TITLE
Creator fix

### DIFF
--- a/contract/src/instruction/factory/claim_funds.rs
+++ b/contract/src/instruction/factory/claim_funds.rs
@@ -25,7 +25,7 @@ impl TryFrom<FrontendClaimFundsArgs> for ClaimFundsArgs {
     fn try_from(args: FrontendClaimFundsArgs) -> Result<Self, Self::Error> {
         Ok(Self {
             payer_pubkey: Pubkey::from_str(&args.payer_pubkey).map_err(|e| e.to_string())?,
-            auction_owner_pubkey: Pubkey::from_str(&args.payer_pubkey)
+            auction_owner_pubkey: Pubkey::from_str(&args.auction_owner_pubkey)
                 .map_err(|e| e.to_string())?,
             auction_id: pad_to_32_bytes(&args.auction_id)?,
             cycle_number: args.cycle_number,

--- a/gold-bot/src/main.rs
+++ b/gold-bot/src/main.rs
@@ -188,6 +188,7 @@ async fn try_close_cycle(
         }
     } else {
         // update pool record cache on success
+        pool_record.increment_cycle_number();
         pool_record.update_cycle_state(client).await?;
         pool_record.reset_error_streak();
     }
@@ -204,6 +205,7 @@ async fn close_cycle(
     pool_record: &mut PoolRecord,
     bot_keypair: &Keypair,
 ) -> Result<(), anyhow::Error> {
+    pool_record.update_cycle_state(client).await?;
     let token_type = match pool_record.root_state.token_config {
         TokenConfig::Nft(_) => TokenType::Nft,
         TokenConfig::Token(_) => TokenType::Token,
@@ -226,7 +228,7 @@ async fn close_cycle(
         auction_owner_pubkey: pool_record.root_state.auction_owner,
         top_bidder_pubkey: top_bidder,
         auction_id: *auction_id,
-        next_cycle_num: pool_record.root_state.status.current_auction_cycle,
+        next_cycle_num: pool_record.current_cycle_number,
         token_type,
         existing_token_mint,
     };

--- a/gold-bot/src/pool_cache.rs
+++ b/gold-bot/src/pool_cache.rs
@@ -19,6 +19,8 @@ pub struct PoolRecord {
     pub root_state: AuctionRootState,
     /// The auction cycle state
     pub cycle_state: AuctionCycleState,
+    /// The current auction cycle
+    pub current_cycle_number: u64,
     /// The number of times an unexpected error occured on consecutive cycle
     /// closings
     pub error_streak: u8,
@@ -46,10 +48,12 @@ impl PoolRecord {
             .get_and_deserialize_account_data(&cycle_pubkey)
             .await?;
 
+        let current_cycle_number = root_state.status.current_auction_cycle;
         Ok(Self {
             root_pubkey,
             root_state,
             cycle_state,
+            current_cycle_number,
             error_streak: 0,
         })
     }
@@ -116,6 +120,11 @@ impl PoolRecord {
     /// Should be used after successful cycle closing.
     pub fn reset_error_streak(&mut self) {
         self.error_streak = 0;
+    }
+
+    /// Increments cycle number in cache
+    pub fn increment_cycle_number(&mut self) {
+        self.current_cycle_number += 1;
     }
 
     /// Returns if the auction is likely broken. Currently identified by


### PR DESCRIPTION
## Description

Aims to resolve #71 . Also adds the auction owner to the creators of the nfts printed. 

In the auction bot all pool records now include the current cycle number.